### PR TITLE
Clang on Mac is needing to have <string> explicitly defined.

### DIFF
--- a/LibChemist/BasisSetManager.cpp
+++ b/LibChemist/BasisSetManager.cpp
@@ -1,6 +1,5 @@
 #include "LibChemist/BasisSetManager.hpp"
 #include "LibChemist/Implementations/BasisSetManagerPIMPL.hpp"
-#include <string> 
 
 namespace LibChemist {
 

--- a/LibChemist/BasisSetManager.hpp
+++ b/LibChemist/BasisSetManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "LibChemist/AOBasisSet.hpp"
+#include <string>
 
 namespace LibChemist {
 namespace detail_ {


### PR DESCRIPTION
## Status

- [ ] Ready to go

## Brief Description
Clang on Mac is needing to have <string> explicitly defined.

## Detailed Description

## TODOs and/or Questions
