### PR TITLE
Should be able to find TA now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ cpp_find_or_build_dependency(
     tiledarray
     URL github.com/ValeevGroup/tiledarray
     BUILD_TARGET tiledarray
+    FIND_TARGET tiledarray
 )
 
 cpp_add_library(


### PR DESCRIPTION
Without this PR the build system doesn't know the target it should get when TA is successfully found. This PR fixes that so you should be able to use a pre-built version of TA.

This PR is r2g.
