### PR TITLE
[r2g] Adding he2, he4, he6, and he8 linear "molecules" for tests.

### DIFF
--- a/libchemist/defaults/nwx_molecule_manager_pimpl.cpp
+++ b/libchemist/defaults/nwx_molecule_manager_pimpl.cpp
@@ -7700,6 +7700,78 @@ private:
                                cart_t{9.061774821421823, -4.23286972296761,
                                       23.592237045995695}});
             return mol;
+        } else if(name == "he2") {
+            auto mol = Molecule();
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 0.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 4.0}});
+            return mol;
+        } else if(name == "he4") {
+            auto mol = Molecule();
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 0.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 4.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 8.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 12.0}});
+            return mol;
+        } else if(name == "he6") {
+            auto mol = Molecule();
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 0.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 4.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 8.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 12.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 16.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 20.0}});
+            return mol;
+        } else if(name == "he8") {
+            auto mol = Molecule();
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 0.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 4.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 8.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 12.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 16.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 20.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 24.0}});
+            mol.push_back(
+              Atom{mass_t(ptable_.get_atom(2).mass()), 2ul, 
+              cart_t{0.0, 0.0, 28.0}});
+            return mol;
         } else
             throw std::out_of_range("Unknown molecule name");
     } // end at_


### PR DESCRIPTION
## Status

- [X] Ready to go

## Brief Description

Adding the linear molecules He_2, He_4, He_6, and He_8 with equidistant positions at a spacing of 4 Bohr (can be accessed with the names "he2", "he4", "he6" and "he8" respectively). I suggest these structures as small test cases, for example for the DLPNO-MP2. 

## Detailed Description

## TODOs and/or Questions
