### PR TITLE
Eliminate possibility of narrowing conversion

### DIFF
--- a/libchemist/ta_helpers/ta_helpers.hpp
+++ b/libchemist/ta_helpers/ta_helpers.hpp
@@ -98,7 +98,7 @@ auto grab_diagonal(TensorType&& t) {
         auto t_tile = t.find({idx[0], idx[0]}).get();
         tile        = tile_type(r);
         for(auto i : r) {
-            std::vector<std::size_t> ii{i[0], i[0]};
+            std::vector ii{i[0], i[0]};
             tile[i] = t_tile[ii];
         }
         return tile.norm();


### PR DESCRIPTION
## Status

- [ x ] Ready to go

## Brief Description

Fixes issues like this:
```
/Users/evaleev/code/NWChemEx/MP2/cmake-build-debug/_deps/libchemist-src/libchemist/ta_helpers/ta_helpers.hpp:101:41: error: non-constant-expression cannot be narrowed from type 'long long' to 'unsigned long' in initializer list [-Wc++11-narrowing]
            std::vector<std::size_t> ii{i[0], i[0]};
                                        ^~~~
/Users/evaleev/code/NWChemEx/MP2/cmake-build-debug/_deps/libchemist-src/libchemist/ta_helpers/ta_helpers.hpp:101:41: note: insert an explicit cast to silence this issue
            std::vector<std::size_t> ii{i[0], i[0]};
                                        ^~~~
                                        static_cast<unsigned long>( )
/Users/evaleev/code/NWChemEx/MP2/cmake-build-debug/_deps/libchemist-src/libchemist/ta_helpers/ta_helpers.hpp:101:47: error: non-constant-expression cannot be narrowed from type 'long long' to 'unsigned long' in initializer list [-Wc++11-narrowing]
            std::vector<std::size_t> ii{i[0], i[0]};
                                              ^~~~
/Users/evaleev/code/NWChemEx/MP2/cmake-build-debug/_deps/libchemist-src/libchemist/ta_helpers/ta_helpers.hpp:101:47: note: insert an explicit cast to silence this issue
            std::vector<std::size_t> ii{i[0], i[0]};
                                              ^~~~
                                              static_cast<unsigned long>( )
```

## Detailed Description

## TODOs and/or Questions
