### PR TITLE
bump version, silence warning, fix type error.

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Lint
         run: .github/workflows/scripts/lint.sh libchemist
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         env:
           GITHUB_TOKEN: ${{ secrets.CREATE_PULL_REQUEST_TOKEN }}
 

--- a/libchemist/orbital_space/derived_space.hpp
+++ b/libchemist/orbital_space/derived_space.hpp
@@ -246,7 +246,7 @@ typename DERIVED_SPACE::overlap_type DERIVED_SPACE::compute_overlap_() const {
         auto i_ma  = lidx + ";mu,a";
         auto j_nb  = ridx + ";nu,b";
 
-        overlap_type buffer;
+        typename FromSpace::overlap_type buffer;
         TA::expressions::einsum(buffer(ij_an), C_ao2x(i_ma), S_ao(ij_mn));
         TA::expressions::einsum(S_deriv(ij_ab), buffer(ij_an), C_ao2x(j_nb));
     } else {

--- a/tests/ta_helpers/get_block_idx.cpp
+++ b/tests/ta_helpers/get_block_idx.cpp
@@ -9,7 +9,7 @@ TEST_CASE("get_block_idx"){
     SECTION("Vector"){
         TA::TiledRange trange{{0, 1, 2}};
         TA::TSpArrayD t(world, trange, {0, 1});
-        for(std::size_t i = 0; i < 2; ++i){
+        for(long i = 0; i < 2; ++i){
             auto idx = get_block_idx(t, t.find(i).get());
             decltype(idx) corr;
             corr.push_back(i);
@@ -20,8 +20,8 @@ TEST_CASE("get_block_idx"){
     SECTION("Matrix"){
         TA::TiledRange trange{{0, 1, 2}, {0, 1, 2}};
         TA::TSpArrayD t(world, trange, {{0, 1}, {2, 3}});
-        for(std::size_t i = 0; i < 2; ++i){
-            for(std::size_t j = 0; j < 2; ++j){
+        for(long i = 0; i < 2; ++i){
+            for(long j = 0; j < 2; ++j){
                 auto idx = get_block_idx(t, t.find({i,j}).get());
                 decltype(idx) corr{i, j};
                 REQUIRE(idx == corr);
@@ -33,9 +33,9 @@ TEST_CASE("get_block_idx"){
         TA::TiledRange trange{{0, 1, 2}, {0, 1, 2}, {0, 1, 2}};
         TA::TSpArrayD t(world, trange, {{{0, 1}, {2, 3}},
                                         {{4, 5}, {6, 7}}});
-        for(std::size_t i = 0; i < 2; ++i){
-            for(std::size_t j = 0; j < 2; ++j){
-                for(std::size_t k = 0; k < 2; ++k) {
+        for(long i = 0; i < 2; ++i){
+            for(long j = 0; j < 2; ++j){
+                for(long k = 0; k < 2; ++k) {
                     auto idx = get_block_idx(t, t.find({i, j, k}).get());
                     decltype(idx) corr{i, j, k};
                     REQUIRE(idx == corr);


### PR DESCRIPTION
This PR:

- bumps the version of create-pull-request used in CI to 3,
- silences some narrowing conversions in the unit tests, and
- fixes an error regarding how an intermediate's type is deduced.

I presume CI is going to fail because of the CBLAS issue raised in #131.
