### PR TITLE
Make FamilyOfSets Usable in a property type

### DIFF
--- a/include/libchemist/set_theory/family_of_sets.hpp
+++ b/include/libchemist/set_theory/family_of_sets.hpp
@@ -26,8 +26,11 @@ namespace libchemist::set_theory {
 template<typename SetType>
 class FamilyOfSets {
 public:
+    /// Type of the set we are dividing up
+    using superset_type = SetType;
+
     /// Type of the subsets in this family of sets
-    using value_type = Subset<SetType>;
+    using value_type = Subset<superset_type>;
 
     /// Type of a read/write-reference to a subset
     using reference_type = value_type&;
@@ -36,7 +39,7 @@ public:
     using const_reference = const value_type&;
 
     /// Type of the pointer holding the superset
-    using ptr_type = std::shared_ptr<const SetType>;
+    using ptr_type = std::shared_ptr<const superset_type>;
 
 private:
     /// Type of the container holding the subsets
@@ -180,6 +183,14 @@ public:
      */
     bool disjoint() const noexcept;
 
+    /** @brief Hashes the FamilyOfSets.
+     *
+     *  @param[in,out] h The Hasher instance to use for hashing the
+     *                   FamilyOfSets. After this call the internal hash of @p h
+     *                   will be updated to include the hash of this instance.
+     */
+    void hash(sde::Hasher& h) const;
+
 private:
     /// Checks that @p i is a valid offset
     void bounds_check_(size_type i) const;
@@ -279,6 +290,12 @@ bool FAMILYOFSETS::disjoint() const noexcept {
         }
     }
     return true;
+}
+
+template<typename SetType>
+void FAMILYOFSETS::hash(sde::Hasher& h) const {
+    for(const auto& x : m_subsets_) h(x);
+    h(*m_obj_);
 }
 
 template<typename SetType>

--- a/include/libchemist/set_theory/set_theory.hpp
+++ b/include/libchemist/set_theory/set_theory.hpp
@@ -2,3 +2,4 @@
 #include "libchemist/set_theory/family_of_sets.hpp"
 #include "libchemist/set_theory/set_traits.hpp"
 #include "libchemist/set_theory/subset.hpp"
+#include "libchemist/set_theory/type_traits.hpp"

--- a/include/libchemist/set_theory/subset.hpp
+++ b/include/libchemist/set_theory/subset.hpp
@@ -4,6 +4,7 @@
 #include <boost/container/flat_set.hpp>
 #include <iterator>
 #include <memory>
+#include <sde/detail_/memoization.hpp>
 
 namespace libchemist::set_theory {
 template<typename SetType>
@@ -392,6 +393,14 @@ public:
      */
     bool operator<(const my_type& rhs) const noexcept;
 
+    /** @brief Hashes the current subset.
+     *
+     *  @param[in,out] h The hasher being used to hash this Subset. After the
+     *                   call, the internal hash of @p h will be updated to
+     *                   include the hash of this Subset.
+     */
+    void hash(sde::Hasher& h) const;
+
 private:
     /// Type of the container holding the set
     using set_type = boost::container::flat_set<size_type>;
@@ -578,6 +587,12 @@ SUBSET SUBSET::operator^(const Subset& rhs) const {
 template<typename SetType>
 bool SUBSET::operator<(const Subset& rhs) const noexcept {
     return m_members_ < rhs.m_members_;
+}
+
+template<typename SetType>
+void SUBSET::hash(sde::Hasher& h) const {
+    for(const auto& x : m_members_) h(x);
+    h(*m_parent_);
 }
 
 template<typename SetType>

--- a/include/libchemist/set_theory/type_traits.hpp
+++ b/include/libchemist/set_theory/type_traits.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include <type_traits>
+
+namespace libchemist::set_theory {
+
+// Forward declare FamilyOfSets for TMP purposes
+template<typename T>
+class FamilyOfSets;
+
+namespace detail_ {
+
+/** @brief Primary template for determining if type @p T is a FamilyOfSets.
+ *
+ *  The primary template is chosen whenever @p T is not an instantiation of
+ *  `FamilyOfSets`. When instantiated the primary template of IsFamilyOfSets
+ *  contains a static constexpr member `value` set to false.
+ *
+ *  @tparam T The type for this trait to determinine whether or not it is an
+ *            instance of `type::FamilyOfSets`.
+ *
+ */
+template<typename T>
+struct IsFamilyOfSets : std::false_type {};
+
+/** @brief Specialization of IsFamilyOfSets for when type @p T is a
+ *         FamilyOfSets.
+ *
+ *  This specialization is chosen whenever @p T is an instantiation of
+ *  `type::FamilyOfSets`. When instantiated this specialization of
+ *  IsFamilyOfSets contains a static constexpr member `value` set to true.
+ *
+ *  @tparam T The type for this trait to determinine whether or not it is an
+ *            instance of `type::FamilyOfSets`.
+ */
+template<typename T>
+struct IsFamilyOfSets<set_theory::FamilyOfSets<T>> : std::true_type {};
+
+} // namespace detail_
+
+/** @brief Public API for determining if a type @p T is the type of a
+ *         FamilyOfSets.
+ *
+ *  This type trait can be used to determine if @p T is an instantiation of
+ *  FamilyOfSets. It will be set to true if @p T is an instantiation of
+ *  FamilyOfSets and false otherwise.
+ *
+ *  @tparam T This trait will determine if @p T is a FamilyOfSets.
+ */
+template<typename T>
+static constexpr bool is_family_of_sets_v = detail_::IsFamilyOfSets<T>::value;
+
+} // namespace libchemist::set_theory

--- a/tests/set_theory/family_of_sets.cpp
+++ b/tests/set_theory/family_of_sets.cpp
@@ -9,6 +9,10 @@ TEMPLATE_LIST_TEST_CASE("FamilyOfSets", "", container_types) {
     using container_type = boost::container::flat_set<value_type>;
 
     SECTION("typedefs") {
+        SECTION("superset_type") {
+            using superset_type = typename family_type::superset_type;
+            STATIC_REQUIRE(std::is_same_v<superset_type, parent_type>);
+        }
         SECTION("value_type") {
             using corr = Subset<parent_type>;
             STATIC_REQUIRE(std::is_same_v<value_type, corr>);
@@ -240,6 +244,31 @@ TEMPLATE_LIST_TEST_CASE("FamilyOfSets", "", container_types) {
     SECTION("disjoint") {
         REQUIRE(monomers.disjoint());
         REQUIRE_FALSE(dimers.disjoint());
+    }
+
+    SECTION("hash") {
+        SECTION("Both empty") {
+            auto lhs = sde::hash_objects(defaulted);
+            family_type other(default_obj);
+            auto rhs = sde::hash_objects(other);
+            REQUIRE(lhs == rhs);
+        }
+        SECTION("Different supersets") {
+            auto lhs = sde::hash_objects(defaulted);
+            REQUIRE(lhs != sde::hash_objects(non_default));
+        }
+        SECTION("Same non-empty") {
+            family_type rhs(non_default_obj, {{0ul}, {1ul}, {2ul}});
+            REQUIRE(sde::hash_objects(monomers) == sde::hash_objects(rhs));
+        }
+        SECTION("Different non-empty size") {
+            family_type rhs(non_default_obj, {{0ul}, {1ul}});
+            REQUIRE(sde::hash_objects(monomers) != sde::hash_objects(rhs));
+        }
+        SECTION("Different non-empty subset") {
+            family_type rhs(non_default_obj, {{0ul}, {1ul}, {0ul, 1ul}});
+            REQUIRE(sde::hash_objects(monomers) != sde::hash_objects(rhs));
+        }
     }
 
     SECTION("Comparisons") {

--- a/tests/set_theory/subset.cpp
+++ b/tests/set_theory/subset.cpp
@@ -510,6 +510,43 @@ TEMPLATE_LIST_TEST_CASE("Subset", "", container_types) {
         SECTION("Same subset") { REQUIRE_FALSE(e0 < e0); }
     }
 
+    SECTION("hash") {
+        SECTION("Different parent objects") {
+            auto lhs = sde::hash_objects(empty_defaulted);
+            auto rhs = sde::hash_objects(empty_non_defaulted);
+            REQUIRE(lhs != rhs);
+        }
+        SECTION("Empty sets are equal") {
+            SECTION("Empty parent set") {
+                auto lhs = sde::hash_objects(empty_defaulted);
+                subset_type s(default_ptr);
+                auto rhs = sde::hash_objects(s);
+                REQUIRE(lhs == rhs);
+            }
+
+            SECTION("Non-empty parent set") {
+                auto lhs = sde::hash_objects(empty_non_defaulted);
+                subset_type s(non_default_ptr);
+                auto rhs = sde::hash_objects(s);
+                REQUIRE(lhs == rhs);
+            }
+        }
+        SECTION("Different number of elements") {
+            REQUIRE(sde::hash_objects(e0) != sde::hash_objects(e01));
+        }
+
+        SECTION("Different elements") {
+            REQUIRE(sde::hash_objects(e0) != sde::hash_objects(e2));
+        }
+
+        SECTION("Same elements") {
+            auto lhs = sde::hash_objects(e0);
+            subset_type s(non_default_ptr, {0ul});
+            auto rhs = sde::hash_objects(s);
+            REQUIRE(lhs == rhs);
+        }
+    }
+
     SECTION("Comparisons") {
         SECTION("Different types") {
             using parent_type = std::vector<double>;

--- a/tests/set_theory/type_traits.cpp
+++ b/tests/set_theory/type_traits.cpp
@@ -1,0 +1,25 @@
+#include "libchemist/set_theory/type_traits.hpp"
+#include <catch2/catch.hpp>
+#include <vector>
+
+using namespace libchemist::set_theory;
+
+using type_list = std::tuple<int, double, float, std::string>;
+
+TEMPLATE_LIST_TEST_CASE("IsFamilyOfSets", "", type_list) {
+    using T   = TestType;
+    using fos = FamilyOfSets<std::vector<T>>;
+    SECTION("Not a family of sets") {
+        STATIC_REQUIRE_FALSE(detail_::IsFamilyOfSets<T>::value);
+    }
+    SECTION("Is a family of sets") {
+        STATIC_REQUIRE(detail_::IsFamilyOfSets<fos>::value);
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("is_family_of_sets_v", "", type_list) {
+    using T   = TestType;
+    using fos = FamilyOfSets<std::vector<T>>;
+    SECTION("Not a family") { STATIC_REQUIRE_FALSE(is_family_of_sets_v<T>); }
+    SECTION("Is a family") { STATIC_REQUIRE(is_family_of_sets_v<fos>); }
+}


### PR DESCRIPTION
This PR adds hashing to the `FamilyOfSets` and `Subset` classes so they can be used in property types. I also migrated some type traits for `FamilyOfSet` I had sitting around. This PR is r2g.
