### PR TITLE
Freeze SDE version before refactorings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(BUILD_PYBINDINGS "Should we build Python3 bindings?" ON)
 cpp_find_or_build_dependency(
     sde
     URL github.com/NWChemEx-Project/sde
+    VERSION 47ce428c2a2d84b4f18dcb9e62d650871d9262c1
     PRIVATE TRUE
     BUILD_TARGET sde
     FIND_TARGET nwx::sde


### PR DESCRIPTION
## Status

- [x] Ready to go

## Brief Description
It will be better to freeze SDE version to avoid breaking builds for the upstream until the refactorings are done.
## Detailed Description

## TODOs and/or Questions
