### PR TITLE
Update TA version and install PZ before TA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ cpp_find_or_build_dependency(
                BUILD_TESTING=OFF 
                BLAS_THREAD_LAYER=sequential
                MADNESS_ENABLE_CEREAL=ON
-           DEPENDS pluginplay
 )
 
 find_package(Boost REQUIRED COMPONENTS container)


### PR DESCRIPTION
## Status

- [x] Ready to go

## Brief Description
Adapts to the [recent changes](https://github.com/ValeevGroup/tiledarray/pull/300) in TA that makes use of FetchContent to install MADNESS instead of ExternalProject.
Required to fix ParallelZone [issue #15](https://github.com/NWChemEx-Project/ParallelZone/issues/15) and [PR #21](https://github.com/NWChemEx-Project/ParallelZone/pull/21).
## Detailed Description

## TODOs and/or Questions
