### PR TITLE
Enables subtraction between const tensors

### DIFF
--- a/include/libchemist/tensor/detail_/operations/subt_op.hpp
+++ b/include/libchemist/tensor/detail_/operations/subt_op.hpp
@@ -41,6 +41,9 @@ private:
 
 /** @brief Syntactic sugar for generating a SubtOp instance.
  *
+ *  These four overloads of operator- allow you to subtract tensor wrappers of
+ *  different const-ness via the expression layer.
+ *
  *  @relates SubtOp
  *
  *  @tparam LHSType The type of the expression on the left of the minus sign.
@@ -53,10 +56,27 @@ private:
  *
  *  @return A SubtOp object describing the subtraction to perform.
  */
+///@{
 template<typename LHSType, typename RHSType>
 auto operator-(OpLayer<LHSType>& lhs, OpLayer<RHSType>& rhs) {
     return SubtOp<LHSType, RHSType>(lhs.downcast(), rhs.downcast());
 }
+
+template<typename LHSType, typename RHSType>
+auto operator-(const OpLayer<LHSType>& lhs, OpLayer<RHSType>& rhs) {
+    return SubtOp<LHSType, RHSType>(lhs.downcast(), rhs.downcast());
+}
+
+template<typename LHSType, typename RHSType>
+auto operator-(OpLayer<LHSType>& lhs, const OpLayer<RHSType>& rhs) {
+    return SubtOp<LHSType, RHSType>(lhs.downcast(), rhs.downcast());
+}
+
+template<typename LHSType, typename RHSType>
+auto operator-(const OpLayer<LHSType>& lhs, const OpLayer<RHSType>& rhs) {
+    return SubtOp<LHSType, RHSType>(lhs.downcast(), rhs.downcast());
+}
+///@}
 
 // ------------------------ Implementations ------------------------------------
 

--- a/tests/tensor/detail_/operations/subt_op.cpp
+++ b/tests/tensor/detail_/operations/subt_op.cpp
@@ -38,7 +38,7 @@ TEMPLATE_LIST_TEST_CASE("SubtOp", "", type::tensor_variant) {
 
     TWrapper result(t_type{});
 
-    SECTION("operator-(other labeled tensor)") {
+    SECTION("operator-(labeled tensor, labeled tensor)") {
         SECTION("vector") {
             result("i") = lvec - lvec;
             auto& rv    = result.get<t_type>();
@@ -54,6 +54,81 @@ TEMPLATE_LIST_TEST_CASE("SubtOp", "", type::tensor_variant) {
         }
         SECTION("rank-3 tensor") {
             result("i,j,k") = lt3 - lt3;
+            auto& rv        = result.get<t_type>();
+            t_type corr(
+              world,
+              tensor_il{matrix_il{vector_il{0.0, 0.0}, vector_il{0.0, 0.0}},
+                        matrix_il{vector_il{0.0, 0.0}, vector_il{0.0, 0.0}}});
+            REQUIRE(libchemist::ta_helpers::allclose(rv, corr));
+        }
+    }
+
+    SECTION("operator-(labeled tensor, const labeled tensor)") {
+        SECTION("vector") {
+            result("i") = lvec - std::as_const(lvec);
+            auto& rv    = result.get<t_type>();
+            t_type corr(world, vector_il{0.0, 0.0, 0.0});
+            REQUIRE(libchemist::ta_helpers::allclose(rv, corr));
+        }
+        SECTION("matrix") {
+            result("i,j") = lmat - std::as_const(lmat);
+            auto& rv      = result.get<t_type>();
+            t_type corr(world,
+                        matrix_il{vector_il{0.0, 0.0}, vector_il{0.0, 0.0}});
+            REQUIRE(libchemist::ta_helpers::allclose(rv, corr));
+        }
+        SECTION("rank-3 tensor") {
+            result("i,j,k") = lt3 - std::as_const(lt3);
+            auto& rv        = result.get<t_type>();
+            t_type corr(
+              world,
+              tensor_il{matrix_il{vector_il{0.0, 0.0}, vector_il{0.0, 0.0}},
+                        matrix_il{vector_il{0.0, 0.0}, vector_il{0.0, 0.0}}});
+            REQUIRE(libchemist::ta_helpers::allclose(rv, corr));
+        }
+    }
+
+    SECTION("operator-(const labeled tensor, labeled tensor)") {
+        SECTION("vector") {
+            result("i") = std::as_const(lvec) - lvec;
+            auto& rv    = result.get<t_type>();
+            t_type corr(world, vector_il{0.0, 0.0, 0.0});
+            REQUIRE(libchemist::ta_helpers::allclose(rv, corr));
+        }
+        SECTION("matrix") {
+            result("i,j") = std::as_const(lmat) - lmat;
+            auto& rv      = result.get<t_type>();
+            t_type corr(world,
+                        matrix_il{vector_il{0.0, 0.0}, vector_il{0.0, 0.0}});
+            REQUIRE(libchemist::ta_helpers::allclose(rv, corr));
+        }
+        SECTION("rank-3 tensor") {
+            result("i,j,k") = std::as_const(lt3) - lt3;
+            auto& rv        = result.get<t_type>();
+            t_type corr(
+              world,
+              tensor_il{matrix_il{vector_il{0.0, 0.0}, vector_il{0.0, 0.0}},
+                        matrix_il{vector_il{0.0, 0.0}, vector_il{0.0, 0.0}}});
+            REQUIRE(libchemist::ta_helpers::allclose(rv, corr));
+        }
+    }
+
+    SECTION("operator-(const labeled tensor, const labeled tensor)") {
+        SECTION("vector") {
+            result("i") = std::as_const(lvec) - std::as_const(lvec);
+            auto& rv    = result.get<t_type>();
+            t_type corr(world, vector_il{0.0, 0.0, 0.0});
+            REQUIRE(libchemist::ta_helpers::allclose(rv, corr));
+        }
+        SECTION("matrix") {
+            result("i,j") = std::as_const(lmat) - std::as_const(lmat);
+            auto& rv      = result.get<t_type>();
+            t_type corr(world,
+                        matrix_il{vector_il{0.0, 0.0}, vector_il{0.0, 0.0}});
+            REQUIRE(libchemist::ta_helpers::allclose(rv, corr));
+        }
+        SECTION("rank-3 tensor") {
+            result("i,j,k") = std::as_const(lt3) - std::as_const(lt3);
             auto& rv        = result.get<t_type>();
             t_type corr(
               world,


### PR DESCRIPTION
Originally subtraction of tensors was only defined between two non-const instances. This PR adds the APIs for subtracting a const with a non-const, a non-const with a const, and a const with a const. It's r2g.
