### PR TITLE
Remove zero columns from remove_redundancy result

### DIFF
--- a/src/libchemist/ta_helpers/remove_redundancy.hpp
+++ b/src/libchemist/ta_helpers/remove_redundancy.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "libchemist/ta_helpers/einsum/einsum.hpp"
 #include "libchemist/ta_helpers/linalg_inner_tensors.hpp"
+#include "libchemist/ta_helpers/slice.hpp"
 #include "libchemist/ta_helpers/ta_helpers.hpp"
 #include <TiledArray/expressions/contraction_helpers.h>
 
@@ -9,24 +10,33 @@ namespace libchemist::ta_helpers {
 template<typename T>
 auto remove_redundancy(const T& C, const T& S, double thresh = 1.0E-8) {
     // Diagonalize S, compute diagonal of S^0.5 with redundant elements zeroed
-    auto [evals, evecs] = TA::heig(S);
-    for(auto& x : evals) x = x >= thresh ? 1.0 / std::sqrt(x) : 0.0;
+    auto [evals, evecs]   = TA::heig(S);
+    std::size_t n_nonzero = 0;
+    decltype(evals) non0_evals;
+    for(auto& x : evals) {
+        if(x < thresh) continue;
+        non0_evals.push_back(1.0 / std::sqrt(x));
+        ++n_nonzero;
+    }
+
+    auto extents = evecs.elements_range().extent();
+    std::size_t hi0(extents[0]), hi1(extents[1]);
+    sparse_map::ElementIndex lo{0, hi1 - n_nonzero};
+    sparse_map::ElementIndex hi{hi0, hi1};
+    auto non0_evecs = slice(evecs, lo, hi);
+
     using tensor_type = std::decay_t<decltype(evecs)>;
 
-    auto l = [evals = evals](auto& tile, const auto& range) {
+    auto l = [=](auto& tile, const auto& range) {
         tile = std::decay_t<decltype(tile)>(range);
-        for(auto i : range) tile(i) = evals[i[0]];
+        for(auto i : range) tile(i) = non0_evals[i[0]];
         return tile.norm();
     };
+
     auto new_evals = TA::make_array<tensor_type>(
-      evecs.world(), TA::TiledRange{evecs.trange().dim(0)}, l);
+      evecs.world(), TA::TiledRange{non0_evecs.trange().dim(1)}, l);
 
-    // TODO: use einsum from TA
-    //    T evecs_bar;
-    //    TA::expressions::einsum(evecs_bar("i,j"), evecs("i,j"),
-    //    new_evals("j"));
-
-    auto evecs_bar = einsum::einsum("i,j", "i,j", "j", evecs, new_evals);
+    auto evecs_bar = einsum::einsum("i,j", "i,j", "j", non0_evecs, new_evals);
     // Make AO to NRPAO transform and return it
     T NewC;
     NewC("mu,nu") = C("mu,lambda") * evecs_bar("lambda,nu");

--- a/src/libchemist/tensor/remove_redundancy.cpp
+++ b/src/libchemist/tensor/remove_redundancy.cpp
@@ -1,4 +1,4 @@
-#include "libchemist/ta_helpers/remove_redundancy.hpp"
+#include "../ta_helpers/remove_redundancy.hpp"
 #include "libchemist/tensor/remove_redundancy.hpp"
 #include "libchemist/tensor/tensor_wrapper.hpp"
 

--- a/tests/ta_helpers/remove_redundancy.cpp
+++ b/tests/ta_helpers/remove_redundancy.cpp
@@ -39,10 +39,8 @@ TEST_CASE("remove_redundancy") {
 
     SECTION("One redundancy") {
         auto NRC = remove_redundancy(CTilde_corr, STilde_corr, 0.1);
-        // Note this differs from NRC_corr_data by the second column being 0
-        tensor_type NRC_corr(world,
-                             matrix_il{vector_il{0.0, -0.8093539841320377},
-                                       vector_il{0.0, 0.8093539841320377}});
+        tensor_type NRC_corr(world, matrix_il{vector_il{-0.8093539841320377},
+                                              vector_il{0.8093539841320377}});
         REQUIRE(allclose(NRC, NRC_corr));
     }
 }

--- a/tests/tensor/remove_redundancy.cpp
+++ b/tests/tensor/remove_redundancy.cpp
@@ -23,8 +23,8 @@ constexpr matrix_il NRC_corr_data{
   vector_il{0.6358462574920218, -0.8093539841320376},
   vector_il{0.6358462574920218, 0.8093539841320376}};
 
-constexpr matrix_il NRC_1_corr_data{vector_il{0.0, -0.8093539841320377},
-                                    vector_il{0.0, 0.8093539841320377}};
+constexpr matrix_il NRC_1_corr_data{vector_il{-0.8093539841320377},
+                                    vector_il{0.8093539841320377}};
 
 } // namespace
 


### PR DESCRIPTION
As `remove_redundancy` currently works you get back the same number of vectors as you put in. For example say you gave `remove_redundancy` 3 column vectors, if the first vector was redundant you'd get back something like (assuming three components in each column vector):

```
0 x0 y0
0 x1 y1
0 x2 y2
```

this PR removes the zeroed out columns in the return value. Continuing with the above example, this means you get back
something like:

```
x0 y0
x1 y1
x2 y2
```

This PR is ready to go, but will probably break anything that relied on the old functionality.