### PR TITLE
Adds ChemicalSystem()::charge

### DIFF
--- a/include/libchemist/chemical_system/chemical_system.hpp
+++ b/include/libchemist/chemical_system/chemical_system.hpp
@@ -45,6 +45,9 @@ public:
     /// Type used for counting/indexing
     using size_type = std::size_t;
 
+    /// Type used to store the charge of the system
+    using charge_type = int;
+
     /** @brief Creates a new ChemicalSystem with default constructed members.
      *
      *  @throws std::bad_alloc if there is an error while allocating the PIMPL.
@@ -171,6 +174,21 @@ public:
      *         guarantee.
      */
     size_type nelectrons() const;
+
+    /** @brief Returns the electronic charge of the system.
+     *
+     *  The charge of the system is based off of the number of electrons and
+     *  the atomic numbers of the nuclei. To change the charge of the system,
+     *  change the number of electrons (or add/remove nuclei).
+     *
+     *  @note By fiat we define an empty system to have no charge.
+     *
+     *  @return -1 times the net number of electrons (relative to the neutral
+     *          system).
+     *
+     *  @throw None no throw guarantee.
+     */
+    charge_type charge() const noexcept;
 
     /** @brief Returns the external electrostatic potential in a read/write
      *         state.

--- a/src/libchemist/chemical_system/chemical_system.cpp
+++ b/src/libchemist/chemical_system/chemical_system.cpp
@@ -59,6 +59,15 @@ size_type& ChemicalSystem::nelectrons() { return pimpl_().nelectrons(); }
 
 size_type ChemicalSystem::nelectrons() const { return pimpl_().nelectrons(); }
 
+typename ChemicalSystem::charge_type ChemicalSystem::charge() const noexcept {
+    if(!m_pimpl_) return charge_type{0};
+    std::size_t neutral = 0;
+    const auto nes      = nelectrons();
+    for(const auto& atomi : molecule()) neutral += atomi.Z();
+    if(neutral < nes) return -1 * charge_type(nes - neutral);
+    return charge_type(neutral - nes);
+}
+
 epot_t& ChemicalSystem::external_electrostatic_potential() {
     return pimpl_().external_electrostatic_potential();
 }

--- a/tests/chemical_system/chemical_system.cpp
+++ b/tests/chemical_system/chemical_system.cpp
@@ -58,6 +58,11 @@ TEST_CASE("ChemicalSystem") {
             using corr_t           = const potentials::Electrostatic&;
             STATIC_REQUIRE(std::is_same_v<const_epot_ref_t, corr_t>);
         }
+
+        SECTION("charge_type") {
+            using corr_t      = int;
+            using charge_type = typename ChemicalSystem::charge_type;
+        }
     }
 
     libchemist::Molecule default_mol, h{libchemist::Atom(1ul)};
@@ -69,6 +74,7 @@ TEST_CASE("ChemicalSystem") {
         ChemicalSystem sys;
         REQUIRE(sys.molecule() == default_mol);
         REQUIRE(sys.nelectrons() == 0);
+        REQUIRE(sys.charge() == 0);
         REQUIRE(sys.external_electrostatic_potential() == default_v);
     }
 
@@ -78,6 +84,7 @@ TEST_CASE("ChemicalSystem") {
         REQUIRE(sys == copy);
         REQUIRE(copy.molecule() == h);
         REQUIRE(copy.nelectrons() == 2);
+        REQUIRE(copy.charge() == -1);
         REQUIRE(copy.external_electrostatic_potential() == v);
     }
 
@@ -86,6 +93,7 @@ TEST_CASE("ChemicalSystem") {
         ChemicalSystem moved(std::move(sys));
         REQUIRE(moved.molecule() == h);
         REQUIRE(moved.nelectrons() == 2);
+        REQUIRE(moved.charge() == -1);
         REQUIRE(moved.external_electrostatic_potential() == v);
     }
 
@@ -94,12 +102,14 @@ TEST_CASE("ChemicalSystem") {
             ChemicalSystem sys(h);
             REQUIRE(sys.molecule() == h);
             REQUIRE(sys.nelectrons() == 1);
+            REQUIRE(sys.charge() == 0);
             REQUIRE(sys.external_electrostatic_potential() == default_v);
         }
         SECTION("Default potential") {
             ChemicalSystem sys(h, 2);
             REQUIRE(sys.molecule() == h);
             REQUIRE(sys.nelectrons() == 2);
+            REQUIRE(sys.charge() == -1);
             REQUIRE(sys.external_electrostatic_potential() == default_v);
         }
 
@@ -107,6 +117,7 @@ TEST_CASE("ChemicalSystem") {
             ChemicalSystem sys(h, 2, v);
             REQUIRE(sys.molecule() == h);
             REQUIRE(sys.nelectrons() == 2);
+            REQUIRE(sys.charge() == -1);
             REQUIRE(sys.external_electrostatic_potential() == v);
         }
     }
@@ -185,6 +196,23 @@ TEST_CASE("ChemicalSystem") {
             ChemicalSystem buffer(std::move(sys));
             const auto& csys = sys;
             REQUIRE_THROWS_AS(csys.nelectrons(), std::runtime_error);
+        }
+    }
+
+    SECTION("charge()") {
+        SECTION("Default") {
+            ChemicalSystem sys;
+            REQUIRE(sys.charge() == 0);
+        }
+
+        SECTION("Cation") {
+            ChemicalSystem sys(h, 0);
+            REQUIRE(sys.charge() == 1);
+        }
+
+        SECTION("Anion") {
+            ChemicalSystem sys(h, 100);
+            REQUIRE(sys.charge() == -99);
         }
     }
 


### PR DESCRIPTION
This PR adds a member `charge` to the `ChemicalSystem` class, which returns the electronic charge of the system. It's r2g.