### PR TITLE
Adds a subset lifetime guarantee to FamilyOfSets

### DIFF
--- a/include/libchemist/set_theory/family_of_sets.hpp
+++ b/include/libchemist/set_theory/family_of_sets.hpp
@@ -24,11 +24,11 @@ namespace libchemist::set_theory {
  *  every element of the set appears in one and only one subset).
  *
  *  The FamilyOfSets class is a container which holds the subsets of a parent
- *  set. The parent set is owned by the FamilyOfSets instance to ensure that
- *  references to the parent set's elements remain valid. The subsets are
- *  lightweight views of the parent set which avoid copying elements of the
- *  parent set while still providing object-oriented access semantics to the
- *  elements.
+ *  set. The FamilyOfSets, and its subsets, share ownership of the parent set.
+ *  This means the subsets remain valid even if the originating FamilyOfSets
+ *  instance goes out of scope. The subsets are lightweight views of the parent
+ *  set which avoid copying elements of the parent set while still providing
+ *  object-oriented access semantics to the elements.
  *
  *  @tparam SetType The type of the parent set. @p SetType must be copy and/or
  *                  move constructable. Additionally `SetTraits<SetType>` must

--- a/tests/set_theory/family_of_sets.cpp
+++ b/tests/set_theory/family_of_sets.cpp
@@ -313,6 +313,18 @@ TEMPLATE_LIST_TEST_CASE("FamilyOfSets", "", container_types) {
             REQUIRE(defaulted != rhs);
         }
     }
+
+    SECTION("Subsets work when FoS goes out of scope") {
+        value_type subset = m0;
+        {
+            auto non_default_obj2 = testing::make_object<TestType>();
+            family_type f(non_default_obj2, {{0ul}, {1ul}, {2ul}});
+            subset = f[1];
+        }
+        REQUIRE(subset.object() == non_default_obj);
+        REQUIRE(subset.size() == 1);
+        REQUIRE(subset.count(non_default_obj[1]));
+    }
 }
 
 TEST_CASE("FamilyOfSets<tuple>") {


### PR DESCRIPTION
This is a small PR which:

- [x] modifies the wording of the `FamilyOfSets` class to expressly state that the subsets may out live the FOS, and
- [x] adds a unit test to ensure future changes do not break this behavior. 

It's r2g.