### PR TITLE
Subset Fix

### DIFF
--- a/include/chemist/set_theory/subset.hpp
+++ b/include/chemist/set_theory/subset.hpp
@@ -593,6 +593,7 @@ SUBSET SUBSET::operator^(const Subset& rhs) const {
 
 template<typename SetType>
 bool SUBSET::operator<(const Subset& rhs) const noexcept {
+    if(object() != rhs.object()) return false;
     return m_members_ < rhs.m_members_;
 }
 

--- a/tests/set_theory/subset.cpp
+++ b/tests/set_theory/subset.cpp
@@ -510,6 +510,11 @@ TEMPLATE_LIST_TEST_CASE("Subset", "", container_types) {
             REQUIRE_FALSE(e2 < e01);
         }
         SECTION("Same subset") { REQUIRE_FALSE(e0 < e0); }
+
+        SECTION("Different parents") {
+            REQUIRE_FALSE(empty_defaulted < e0);
+            REQUIRE_FALSE(e0 < empty_defaulted);
+        }
     }
 
     SECTION("hash") {


### PR DESCRIPTION
## Status

- [x] Ready to go

## Brief Description

Subset comparison operator did not check to make sure the subsets had the same parent set. This leads to weird results when the subset is used as a key in a map. In such a case calling the `count` member of the map would erroneously tell you the map contains the subset if the subsets contained the same indices (map uses `operator<` even for equality comparisons).
