### PR TITLE
small doc change for intended Determinant use

### DIFF
--- a/include/chemist/wavefunction/determinant_space.hpp
+++ b/include/chemist/wavefunction/determinant_space.hpp
@@ -90,7 +90,8 @@ public:
      *                 determinant.
      *  @param[in] virt The orbitals that can be used to form the rest of the
      *                  determinant space.
-     *  @param[in] fock The Fock operator which generated these orbitals.
+     *  @param[in] fock The Fock operator associated with the density of the
+     *                  occupied orbitals.
      *
      *  @throw None No throw gurantee
      */


### PR DESCRIPTION
## Brief Description
Small clarification on which Fock operator should be stored in a `determinant_space`
