### PR TITLE
Fix gcc9.2 build

### DIFF
--- a/src/chemist/wavefunction/many_body.cpp
+++ b/src/chemist/wavefunction/many_body.cpp
@@ -34,7 +34,7 @@ bool MANY_BODY::operator==(const ManyBody& rhs) const {
         if(rhs.m_pref_) return false;
     }
 
-    if (m_order_ != rhs.m_order_) {
+    if(m_order_ != rhs.m_order_) {
         return false;
     } else {
         for(std::size_t i = 0; i < m_order_; ++i) {


### PR DESCRIPTION
## Status

- [x] Ready to go

## Brief Description
I had to do this change to build with gcc 9.2. It was giving the following error:

```
[587/644] Building CXX object CMakeFiles/chemist.dir/src/chemist/wavefunction/many_body.cpp.o
FAILED: CMakeFiles/chemist.dir/src/chemist/wavefunction/many_body.cpp.o 
/soft/compilers/gcc/9.2.0/linux-rhel7-x86_64/bin/c++ -DBPHASH_USE_TYPEID -DBTAS_HAS_BLAS_LAPACK=1 -DBTAS_HAS_BOOST_SERIALIZATION=1 -DBTAS_HAS_INTEL_MKL=1 -DLAPACK_COMPLEX_CPP=1 -DMADNESS_HAS_CEREAL -DMADNESS_MPI_HEADER=\"/soft/libraries/mpi/openmpi/4.1.1/include/mpi.h\" -Dchemist_EXPORTS -I/home/keceli/gpfs_keceli/nwx/Chemist/include -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/tensorwrapper-src/include -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/utilities-src -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/parallelzone-src/include -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/madworld-src/src -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/madworld-build/src -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/madworld-build/src/madness/world -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/madworld-src/src/madness/world -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/cereal-src/include -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/cereal-build -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/cereal-src -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/bphash-src -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/tiledarray-src/src -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/tiledarray-build/src -I/soft/restricted/CNDA/sdk/2022.01.30.001/oneapi/mkl/20220311/mkl/include -I/home/keceli/gpfs_keceli/nwx/eigen -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/btas-src -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/blaspp-build/include -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/blaspp-src/include -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/lapackpp-build/include -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/lapackpp-src/include -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/umpire-src/src -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/umpire-src/src/umpire/tpl/camp/include -I/home/keceli/gpfs_keceli/nwx/Chemist/build_c_220609/_deps/umpire-build/include -isystem /soft/libraries/mpi/openmpi/4.1.1/include -isystem /gpfs/jlse-fs0/users/keceli/nwx/boost/boost_1_79_0 -O3 -DNDEBUG -fPIC   -Wfatal-errors -Wfatal-errors -pthread -fopenmp -std=c++17 -MD -MT CMakeFiles/chemist.dir/src/chemist/wavefunction/many_body.cpp.o -MF CMakeFiles/chemist.dir/src/chemist/wavefunction/many_body.cpp.o.d -o CMakeFiles/chemist.dir/src/chemist/wavefunction/many_body.cpp.o -c /home/keceli/gpfs_keceli/nwx/Chemist/src/chemist/wavefunction/many_body.cpp
/home/keceli/gpfs_keceli/nwx/Chemist/src/chemist/wavefunction/many_body.cpp: In member function ‘bool chemist::wavefunction::ManyBody<ReferenceType, TensorType>::operator==(const chemist::wavefunction::ManyBody<ReferenceType, TensorType>&) const’:
/home/keceli/gpfs_keceli/nwx/Chemist/src/chemist/wavefunction/many_body.cpp:37:42: error: ‘rhs’ is not a constant expression
   37 |     if constexpr(m_order_ != rhs.m_order_) {
      |                                          ^
compilation terminated due to -Wfatal-errors.
```
## Detailed Description

## TODOs and/or Questions
I am not sure if this is the right approach to fix this problem, but it didn't break any tests in the upstream.