### PR TITLE
Fix AOSpace comparison

### DIFF
--- a/src/python/orbital_space/export_ao_space.cpp
+++ b/src/python/orbital_space/export_ao_space.cpp
@@ -2,6 +2,8 @@
 #include "chemist/orbital_space/ao_space.hpp"
 #include "chemist/orbital_space/base_space.hpp"
 #include "export_ao_space.hpp"
+#include <pybind11/operators.h>
+
 namespace chemist {
 namespace detail_ {
 
@@ -21,11 +23,8 @@ void export_ao_space_(const char* name, python_module_reference m) {
         [](aos_type& self, basis_type& basis) {
             self.basis_set() = std::move(basis);
         })
-      .def("__eq__", [](const aos_type& self,
-                        const aos_type& other) { return self == other; })
-      .def("__ne__", [](const aos_type& self, const aos_type& other) {
-          return self != other;
-      });
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self != pybind11::self);
 }
 
 } // namespace detail_


### PR DESCRIPTION
When I run SCF calculations with Python, it was failing sometimes with the following error:
```gdb
3: Test timeout computed to be: 1500
3: [2023-10-26 18:05:51.036] [Rank 0] [info] SCF Converged in 10 Cycles.
3: terminate called after throwing an instance of 'pybind11::error_already_set'
3:   what():  TypeError: __eq__(): incompatible function arguments. The following argument types are supported:
3:     1. (self: chemist.AOSpaceD, arg0: chemist.AOSpaceD) -> bool
3:
3: Invoked with: <chemist.AOSpaceD object at 0x7faddc307bf0>, <chemist.Molecule object at 0x7fadf11c8f70>
3: [nwx:142313] *** Process received signal ***
3: [nwx:142313] Signal: Aborted (6)
3: [nwx:142313] Signal code:  (-6)
3: [nwx:142313] [ 0] /lib/x86_64-linux-gnu/libc.so.6(+0x42520)[0x7fadf2842520]
3: [nwx:142313] [ 1] /lib/x86_64-linux-gnu/libc.so.6(pthread_kill+0x12c)[0x7fadf28969fc]
3: [nwx:142313] [ 2] /lib/x86_64-linux-gnu/libc.so.6(raise+0x16)[0x7fadf2842476]
3: [nwx:142313] [ 3] /lib/x86_64-linux-gnu/libc.so.6(abort+0xd3)[0x7fadf28287f3]
3: [nwx:142313] [ 4] /lib/x86_64-linux-gnu/libstdc++.so.6(+0xa2b9e)[0x7fadf14a2b9e]
3: [nwx:142313] [ 5] /lib/x86_64-linux-gnu/libstdc++.so.6(+0xae20c)[0x7fadf14ae20c]
3: [nwx:142313] [ 6] /lib/x86_64-linux-gnu/libstdc++.so.6(+0xad1e9)[0x7fadf14ad1e9]
3: [nwx:142313] [ 7] /lib/x86_64-linux-gnu/libstdc++.so.6(__gxx_personality_v0+0x99)[0x7fadf14ad959]
3: [nwx:142313] [ 8] /lib/x86_64-linux-gnu/libgcc_s.so.1(+0x16884)[0x7fadf1e1a884]
3: [nwx:142313] [ 9] /lib/x86_64-linux-gnu/libgcc_s.so.1(_Unwind_RaiseException+0x311)[0x7fadf1e1af41]
3: [nwx:142313] [10] /lib/x86_64-linux-gnu/libstdc++.so.6(__cxa_throw+0x3b)[0x7fadf14ae4cb]
3: [nwx:142313] [11] /home/keceli/soft/nwx/NWChemEx/build/pyscf_231026092940/_deps/simde-build/simde.so(+0xdeb5a)[0x7fadd0eecb5a]
3: [nwx:142313] [12] /home/keceli/soft/nwx/NWChemEx/build/pyscf_231026092940/_deps/simde-build/simde.so(+0xd411e)[0x7fadd0ee211e]
3: [nwx:142313] [13] /home/keceli/soft/nwx/NWChemEx/build/pyscf_231026092940/_deps/simde-build/simde.so(_ZNK10pluginplay6python13PythonWrappereqERKS1_+0x7f)[0x7fadd0ed174f]
3: [nwx:142313] [14] /home/keceli/soft/nwx/NWChemEx/build/pyscf_231026092940/_deps/simde-build/simde.so(_ZNK10pluginplay3any7detail_15AnyFieldWrapperINS_6python13PythonWrapperEE12value_equal_ERKNS1_12AnyFieldBaseE+0x61)[0x7fadd0f23a15]
3: [nwx:142313] [15] /home/keceli/soft/nwx/install/tmpQ_230825181627/lib/pluginplay/libpluginplay.so.1(_ZNK10pluginplay5cache8database10TransposerINS_3any8AnyFieldENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEE6count_ERKS4_+0xa3)[0x7fade3e61243]
3: [nwx:142313] [16] /home/keceli/soft/nwx/install/tmpQ_230825181627/lib/pluginplay/libpluginplay.so.1(_ZN10pluginplay5cache10UUIDMapperINS_11ModuleInputEE6insertES2_+0x68)[0x7fade3e6a298]
3: [nwx:142313] [17] /home/keceli/soft/nwx/install/tmpQ_230825181627/lib/pluginplay/libpluginplay.so.1(_ZN10pluginplay5cache13ProxyMapMakerISt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS_11ModuleInputEN9utilities7detail_20CaseInsensitiveLess_ESaISt4pairIKS8_S9_EEEE6insertERKSH_+0x5b)[0x7fade3e70b4b]
3: [nwx:142313] [18] /home/keceli/soft/nwx/install/tmpQ_230825181627/lib/pluginplay/libpluginplay.so.1(_ZN10pluginplay5cache8database14KeyProxyMapperISt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS_11ModuleInputEN9utilities7detail_20CaseInsensitiveLess_ESaISt4pairIKS9_SA_EEES3_IS9_NS_12ModuleResultESD_SaISE_ISF_SJ_EEEE7insert_ESI_SM_+0x30)[0x7fade3e70c20]
3: [nwx:142313] [19] /home/keceli/soft/nwx/install/tmpQ_230825181627/lib/pluginplay/libpluginplay.so.1(_ZN10pluginplay5cache11ModuleCache5cacheESt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS_11ModuleInputEN9utilities7detail_20CaseInsensitiveLess_ESaISt4pairIKS8_S9_EEES2_IS8_NS_12ModuleResultESC_SaISD_ISE_SI_EEE+0x1bc)[0x7fade3e748fc]
3: [nwx:142313] [20] /home/keceli/soft/nwx/install/tmpQ_230825181627/lib/pluginplay/libpluginplay.so.1(_ZN10pluginplay7detail_11ModulePIMPL3runESt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS_11ModuleInputEN9utilities7detail_20CaseInsensitiveLess_ESaISt4pairIKS8_S9_EEE+0xb39)[0x7fade3e8a789]
3: [nwx:142313] [21] /home/keceli/soft/nwx/install/tmpQ_230825181627/lib/pluginplay/libpluginplay.so.1(_ZN10pluginplay6Module3runESt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS_11ModuleInputEN9utilities7detail_20CaseInsensitiveLess_ESaISt4pairIKS7_S8_EEE+0x86)[0x7fade3e80786]
3: [nwx:142313] [22] /home/keceli/soft/nwx/pybind_module_dir/pluginplay.so(+0x3fe9e)[0x7fade3f06e9e]
3: [nwx:142313] [23] /home/keceli/soft/nwx/pybind_module_dir/pluginplay.so(+0x4569a)[0x7fade3f0c69a]
3: [nwx:142313] [24] /home/keceli/soft/nwx/pybind_module_dir/pluginplay.so(+0x351dc)[0x7fade3efc1dc]
3: [nwx:142313] [25] /usr/bin/python3.10(+0x15fe0e)[0x5627f1e62e0e]
3: [nwx:142313] [26] /usr/bin/python3.10(_PyObject_MakeTpCall+0x25b)[0x5627f1e595eb]
3: [nwx:142313] [27] /usr/bin/python3.10(+0x16e7bb)[0x5627f1e717bb]
3: [nwx:142313] [28] /usr/bin/python3.10(_PyEval_EvalFrameDefault+0x6152)[0x5627f1e518a2]
3: [nwx:142313] [29] /usr/bin/python3.10(+0x16e4e1)[0x5627f1e714e1]
3: [nwx:142313] *** End of error message ***
3/3 Test #3: py_nwchemex ......................Subprocess aborted***Exception:   8.14 sec
```
I am not sure why this was happening, but this fixes the problem.

<!---
    This is a comment. So are other lines like it. No need to delete them
    before submitting your PR. If you need help on submitting a PR please
    see our tutorial at https://nwchemex-project.github.io/.github/resources/github/pull_request.html
--->

<!---
    As of 12/7/2022 GitHub does not allow multiple PR templates. Our solution
    is to create one master PR template for all use cases, please delete the
    use cases which are not relevant for your PR. Sorry about the extra step.
--->

<!---
    General PR Questions
    ====================
    Please answer all questions in this section for all PRs.
--->

**PR Type**
<!---
    Please check the corresponding box.

    "Breaking change" is a PR which will break existing user-facing code. These
    types of PRs must be discussed in advance. They may be very small, or very
    extensive PRs depending on the change.

    A "feature" is a PR which adds a major new capability, massively overhauls
    an existing feature, writes entirely new documentation pages, or optimizes
    an extensive algorithm. Features usually take at least a week to implement.

    A "patch" is a PR which touches relatively few lines of code. Patches
    usually address bugs, minor performance issues, typos, clarify
    documentation, etc. Most patches are ready to go in a day or two.
--->

- [ ] Breaking change
- [ ] Feature
- [ ] Patch

**Brief Description**
<!---
    In a couple sentences, describe what this pull request will accomplish. If
    there is a corresponding issue please link to it with
    [closing words](
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-
        using-a-keyword)
    as appropriate. If the goal is more complicated than can be articulated in
    a few sentences, please first open an issue and explain it in detail
    there.
--->

**Not In Scope**
<!---
    Some features have obvious extensions or use cases. If you're only targeting
    a specific use case and don't want to worry about other use cases in this
    PR please make that clear. As appropriate, open an issue for anything not in scope that will need to be or
    could be done in the future.
--->



**PR Checklist**

<!---
    This checklist is meant for developers who are part of the NWChemEx-Project
    organization. If you are an outside collaborator, who only occasionally
    contributes little tweaks, we're just happy to get your contribution. The
    reviewers will happily make any changes needed to bring your contribution
    up to snuff.

    For developers who are part of the organization, and outside collaborators making frequent or large contributions, know that the NWChemEx-Project
    organization strives to be an exemplar of code quality. Unless you have
    advance approval, your PR will not be merged until all relevant items on the
    checklist have been addressed. That said, if you're new, we're certainly
    willing to help out, answer questions, and point you to the right resources.
--->

- [ ] [Is documented](https://nwchemex-project.github.io/.github/documenting/index.html)
- [ ] [Is tested](https://nwchemex-project.github.io/.github/testing/index.html)
- [ ] [Adheres to applicable organization standards](https://nwchemex-project.github.io/.github/conventions/index.html)

<!---
    Draft PRs Only
    ==============

    We strongly encourage all PR authors to open PRs as early as possible.
    When you do that your PR is usually not ready for review. Fill this section
    out in that case. Note we encourage breaking PRs down into chunks which
    can be merged within two weeks. If you expect that your TODO list is too
    large please break the PR down into smaller PRs.
--->

**TODOs**
<!---
    Please include a list of what needs to be done beyond the normal PR
    checklist.
--->

- [ ] Task 1
- [ ] Task 2
