### PR TITLE
Cap `get_index` functions patch

### DIFF
--- a/src/python/fragmenting/capping/export_cap.cpp
+++ b/src/python/fragmenting/capping/export_cap.cpp
@@ -43,9 +43,23 @@ void export_cap(python_module_reference m) {
       .def("size", &Cap::size)
       .def("__len__", &Cap::size)
       .def("set_anchor_index", &Cap::set_anchor_index)
-      .def("get_anchor_index", &Cap::get_anchor_index)
+      .def("get_anchor_index",
+           [](Cap& self) {
+               try {
+                   return self.get_anchor_index();
+               } catch(const std::bad_optional_access& e) {
+                   throw std::runtime_error("No Anchor Set");
+               }
+           })
       .def("set_replaced_index", &Cap::set_replaced_index)
-      .def("get_replaced_index", &Cap::get_replaced_index)
+      .def("get_replaced_index",
+           [](Cap& self) {
+               try {
+                   return self.get_replaced_index();
+               } catch(const std::bad_optional_access& e) {
+                   throw std::runtime_error("No Replacement Set");
+               }
+           })
       .def(pybind11::self == pybind11::self)
       .def(pybind11::self != pybind11::self);
 }


### PR DESCRIPTION
**Description**
Patches an error observed with the python bindings of the `Cap::get_anchor_index()` and `Cap::get_replaced_index()` functions. The `bad_optional_access` error was not being equated to a Python `RuntimeError` in some cases. Now the binding catches the access error and throws a replacement `std::runtime_error`, which is properly equated to the Python exception.