### PR TITLE
Pybinding Patches for Molecule and Chemical System

### DIFF
--- a/src/python/chemical_system/export_chemical_system.hpp
+++ b/src/python/chemical_system/export_chemical_system.hpp
@@ -39,7 +39,7 @@ void inline export_chemical_system(python_module_reference m) {
       .def(pybind11::init<molecule_type>())
       .def_property(
         "molecule",
-        [](chemical_system_reference self) { return self.molecule(); },
+        [](chemical_system_reference self) { return &self.molecule(); },
         [](chemical_system_reference self, molecule_type mol) {
             self.molecule() = std::move(mol);
         })

--- a/src/python/chemical_system/molecule/export_molecule.cpp
+++ b/src/python/chemical_system/molecule/export_molecule.cpp
@@ -43,7 +43,9 @@ void export_molecule(python_module_reference m) {
            [](molecule_reference self, atom_type v) {
                return self.push_back(std::move(v));
            })
-      .def("at", [](molecule_reference self, size_type i) { return self[i]; })
+      .def(
+        "at", [](molecule_reference self, size_type i) { return self[i]; },
+        pybind11::keep_alive<0, 1>())
       .def("size", [](molecule_reference self) { return self.size(); })
       .def("charge", &Molecule::charge)
       .def("n_electrons", &Molecule::n_electrons)

--- a/tests/python/unit_tests/chemical_system/molecule/test_molecule.py
+++ b/tests/python/unit_tests/chemical_system/molecule/test_molecule.py
@@ -45,7 +45,7 @@ class TestMolecule(unittest.TestCase):
         self.assertEqual(n0, self.a0.nucleus)
         self.assertEqual(n1, self.a1.nucleus)
 
-        # Fails if livetime not maintained
+        # Fails if lifetime not maintained
         chem_sys = chemist.ChemicalSystem(self.has_value)
         self.assertEqual(chem_sys.molecule.at(0), self.a0.nucleus)
         self.assertEqual(chem_sys.molecule.at(1), self.a1.nucleus)

--- a/tests/python/unit_tests/chemical_system/molecule/test_molecule.py
+++ b/tests/python/unit_tests/chemical_system/molecule/test_molecule.py
@@ -45,6 +45,11 @@ class TestMolecule(unittest.TestCase):
         self.assertEqual(n0, self.a0.nucleus)
         self.assertEqual(n1, self.a1.nucleus)
 
+        # Fails if livetime not maintained
+        chem_sys = chemist.ChemicalSystem(self.has_value)
+        self.assertEqual(chem_sys.molecule.at(0), self.a0.nucleus)
+        self.assertEqual(chem_sys.molecule.at(1), self.a1.nucleus)
+
         # Are views
         n0.x = 42.0
         self.assertEqual(self.has_value.at(0).x, 42.0)
@@ -92,12 +97,12 @@ class TestMolecule(unittest.TestCase):
         # Has value
         self.assertEqual(
             str(self.has_value),
-            ' 0.000000000000000 0.000000000000000 0.000000000000000\nH 2.000000000000000 3.000000000000000 4.000000000000000\n'
+            'H 1.000000000000000 1.000000000000000 1.000000000000000\nH 2.000000000000000 3.000000000000000 4.000000000000000\n'
         )
 
     def setUp(self):
         self.defaulted = chemist.Molecule()
-        self.a0 = chemist.Atom()
+        self.a0 = chemist.Atom('H', 1, 1.0, 1.0, 1.0, 1.0, 1.0)
         self.a1 = chemist.Atom('H', 1, 1.0, 2.0, 3.0, 4.0, 5.0)
         self.has_value = chemist.Molecule()
         self.has_value.push_back(self.a0)

--- a/tests/python/unit_tests/chemical_system/molecule/test_molecule.py
+++ b/tests/python/unit_tests/chemical_system/molecule/test_molecule.py
@@ -97,12 +97,12 @@ class TestMolecule(unittest.TestCase):
         # Has value
         self.assertEqual(
             str(self.has_value),
-            'H 1.000000000000000 1.000000000000000 1.000000000000000\nH 2.000000000000000 3.000000000000000 4.000000000000000\n'
+            ' 0.000000000000000 0.000000000000000 0.000000000000000\nH 2.000000000000000 3.000000000000000 4.000000000000000\n'
         )
 
     def setUp(self):
         self.defaulted = chemist.Molecule()
-        self.a0 = chemist.Atom('H', 1, 1.0, 1.0, 1.0, 1.0, 1.0)
+        self.a0 = chemist.Atom()
         self.a1 = chemist.Atom('H', 1, 1.0, 2.0, 3.0, 4.0, 5.0)
         self.has_value = chemist.Molecule()
         self.has_value.push_back(self.a0)

--- a/tests/python/unit_tests/chemical_system/test_chemical_system.py
+++ b/tests/python/unit_tests/chemical_system/test_chemical_system.py
@@ -23,6 +23,13 @@ class TestChemicalSystem(unittest.TestCase):
         self.assertEqual(self.has_default_mol.molecule, self.default_mol)
         self.assertEqual(self.has_mol.molecule, self.mol)
 
+        # Molecule is referenced
+        self.assertEqual(self.has_mol.molecule.size(), 1)
+        mol_ref = self.has_mol.molecule
+        mol_ref.push_back(chemist.Atom())
+        self.assertEqual(self.has_mol.molecule.size(), 2)
+        self.assertEqual(mol_ref, self.has_mol.molecule)
+
         # Can write to it
         self.defaulted.molecule = self.mol
         self.assertEqual(self.defaulted.molecule, self.mol)


### PR DESCRIPTION
**Description**
Addresses lifetime issues observed in python when interacting with elements of the `Molecule` attribute of a `ChemicalSystem`. `ChemicalSystem.molecule` now properly references the `Molecule`, and `Molecule` is kept alive while there are still references to its elements.