### PR TITLE
Adds NucleiSubset PIMPL

### DIFF
--- a/src/chemist/chemical_system/nucleus/nuclei_view/detail_/nuclei_subset.hpp
+++ b/src/chemist/chemical_system/nucleus/nuclei_view/detail_/nuclei_subset.hpp
@@ -93,9 +93,9 @@ public:
 
     // Deleted to avoid accidental slicing, NucleiView implements them for user
     ///@{
-    NucleiSubset(NucleiSubset&&)                     = delete;
+    NucleiSubset(NucleiSubset&&) = delete;
     NucleiSubset& operator=(const NucleiSubset& rhs) = delete;
-    NucleiSubset& operator=(NucleiSubset&& rhs)      = delete;
+    NucleiSubset& operator=(NucleiSubset&& rhs) = delete;
     ///@}
 
     /** @brief Determines if *this is value equal to @p rhs.

--- a/src/chemist/chemical_system/nucleus/nuclei_view/detail_/nuclei_subset.hpp
+++ b/src/chemist/chemical_system/nucleus/nuclei_view/detail_/nuclei_subset.hpp
@@ -1,202 +1,166 @@
-// /*
-//  * Copyright 2023 NWChemEx-Project
-//  *
-//  * Licensed under the Apache License, Version 2.0 (the "License");
-//  * you may not use this file except in compliance with the License.
-//  * You may obtain a copy of the License at
-//  *
-//  * http://www.apache.org/licenses/LICENSE-2.0
-//  *
-//  * Unless required by applicable law or agreed to in writing, software
-//  * distributed under the License is distributed on an "AS IS" BASIS,
-//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  * See the License for the specific language governing permissions and
-//  * limitations under the License.
-//  */
+/*
+ * Copyright 2023 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-// #pragma once
-// #include "nuclei_view_pimpl.hpp"
+#pragma once
+#include "nuclei_view_pimpl.hpp"
 
-// namespace chemist::detail_ {
+namespace chemist::detail_ {
 
-// /** @brief Implements a NucleiView that is a subset of a Nuclei object.
-//  *
-//  *  This class is primarily envisioned as implementing NucleiView for
-//  *  ``FragmentedNuclei``. In this case, we have a supersystem which is an
-//  *  object of type ``Nuclei`` and the ``FragmentedNuclei`` is a container of
-//  * ``NucleiView`` objects which are views of the supersystem. The views can
-//  * be implemented quite efficiently by storing a pointer to the supersystem
-//  * and the indices of the nuclei in the view.
-//  *
-//  *  @note we have declared the types in a manner which will work if the class
-//  *        needs to be templated down the line. Without templating we do not
-//  *        technically need to pull in the base class's types, nor do we need
-//  *        typename.
-//  */
-// template<typename NucleiType>
-// class NucleiSubset : public NucleiViewPIMPL<NucleiType> {
-// private:
-//     /// Type of the base class
-//     using base_type = NucleiViewPIMPL<NucleiType>;
+/** @brief Implements a NucleiView that is a subset of a Nuclei object.
+ *
+ *  This class is primarily envisioned as implementing NucleiView for
+ *  ``FragmentedNuclei``. In this case, we have a supersystem which is an
+ *  object of type ``Nuclei`` and the ``FragmentedNuclei`` is a container of
+ * ``NucleiView`` objects which are views of the supersystem. The views can
+ * be implemented quite efficiently by storing a view of the supersystem
+ * and the indices of the nuclei in the view.
+ *
+ */
+template<typename NucleiType>
+class NucleiSubset : public NucleiViewPIMPL<NucleiType> {
+private:
+    /// Type of the base class
+    using base_type = NucleiViewPIMPL<NucleiType>;
 
-// public:
-//     /// Type the view is acting as a reference of
-//     using nuclei_type = typename base_type::nuclei_type;
+public:
+    /// The type *this is implementing
+    using typename base_type::parent_type;
 
-//     /// Type of a shared pointer to a nuclei_type object
-//     using nuclei_pointer = std::shared_ptr<NucleiType>;
+    /// Type the view is acting as a reference of
+    using nuclei_type = typename base_type::nuclei_type;
 
-//     /// Type of a pointer to the base PIMPL
-//     using pimpl_pointer = typename base_type::pimpl_pointer;
+    /// Type of a pointer to the base PIMPL
+    using pimpl_pointer = typename base_type::pimpl_pointer;
 
-//     /// Type of a Nucleus object
-//     using value_type = typename base_type::value_type;
+    /// Type of a Nucleus object
+    using value_type = typename base_type::value_type;
 
-//     /// Type of a mutable reference to a Nucleus object
-//     using reference = typename base_type::reference;
+    /// Type of a mutable reference to a Nucleus object
+    using reference = typename base_type::reference;
 
-//     /// Type of a read-only reference to a Nucleus object
-//     using const_reference = typename base_type::const_reference;
+    /// Type of a read-only reference to a Nucleus object
+    using const_reference = typename base_type::const_reference;
 
-//     /// Type nuclei_type uses for indexing and offsets
-//     using size_type = typename nuclei_type::size_type;
+    /// Type nuclei_type uses for indexing and offsets
+    using size_type = typename nuclei_type::size_type;
 
-//     /// Makes a null subset
-//     NucleiSubset() noexcept = default;
+    using member_list_type = typename parent_type::member_list_type;
 
-//     /** @brief Creates a NucleiViewPIMPL which holds a subset of a Nuclei
-//     object
-//      *
-//      *  @tparam BeginItr The type of the iterator pointing to the index of
-//      the
-//      *                   first nucleus.
-//      *  @tparam EndItr The type of the iterator pointing to just past the
-//      index
-//      *                 of the last nucleus.
-//      *
-//      *  @param[in] supersystem The *this will be a subset of.
-//      *  @param[in] begin An iterator which points to the index of the first
-//      *                   nucleus.
-//      *  @param[in] end An iterator which points to just past the index of the
-//      *                 last nucleus.
-//      *
-//      * @throw std::bad_alloc if there is a problem allocating the memory.
-//      Strong
-//      *                       throw guarantee.
-//      *
-//      */
-//     template<typename BeginItr, typename EndItr>
-//     NucleiSubset(nuclei_pointer supersystem, BeginItr&& begin, EndItr&& end)
-//     :
-//       m_nuclei_(supersystem),
-//       m_members_(std::forward<BeginItr>(begin), std::forward<EndItr>(end)) {}
+    /// Makes a null subset
+    NucleiSubset() noexcept = default;
 
-//     /** @brief Initializes *this to a deep copy of @p other.
-//      *
-//      *  The copy ctor deep copies the indices of @p other, and stores a
-//      *  copy of the pointer pointing to the supersystem. In turn, the
-//      resulting
-//      *  object aliases the same supersystem (which is consistent with *this
-//      *  bein the implementaiton of a view).
-//      *
-//      *  @param[in] other The object we are copying.
-//      *
-//      *  @throw std::bad_alloc if there is a problem allocating the new state
-//      *                        for *this. Strong throw guarantee.
-//      */
-//     NucleiSubset(const NucleiSubset& other) = default;
+    /** @brief Creates a view which is a subset of @p supersystem
+     *
+     *  This is the value ctor for the class. It will create a view which
+     *  aliases a subset of @p supersystem.
+     *
+     *  @param[in] supersystm a view which aliases the supersystem.
+     *  @param[in] members Which nuclei in @p supersystem should be included in
+     *                     the subset? Values in @p nuclei should be in the
+     *                     range [0, supersystem.size())
+     *
+     *  @throw None No throw guarantee.
+     */
+    NucleiSubset(parent_type supersystem, member_list_type members) :
+      m_nuclei_(std::move(supersystem)), m_members_(std::move(members)) {}
 
-//     // Deleted to avoid accidental slicing
-//     ///@{
-//     NucleiSubset(NucleiSubset&&)                     = delete;
-//     NucleiSubset& operator=(const NucleiSubset& rhs) = delete;
-//     NucleiSubset& operator=(NucleiSubset&& rhs)      = delete;
-//     ///@}
+    /** @brief Initializes *this to alias the same Nuclei as @p other.
+     *
+     *  The copy ctor deep copies the indices of @p other, and stores a
+     *  copy of the reference to the supersystem. In turn, the resulting
+     *  object aliases the same supersystem (which is consistent with *this
+     *  being the implementation of a view).
+     *
+     *  @param[in] other The object we are copying.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the new state
+     *                        for *this. Strong throw guarantee.
+     */
+    NucleiSubset(const NucleiSubset& other) = default;
 
-//     /** @brief Determines if *this is value equal to @p rhs.
-//      *
-//      *  We define two NucleiSubset objects as being value equal if they both
-//      *  are null, or if they both are the same subset of the same
-//      supersystem.
-//      *  Supersystems are comapred by value, meaning they do NOT have to be
-//      the
-//      *  same instance.
-//      *
-//      *  @param[in] rhs The NucleiSubset we are comparing to.
-//      *
-//      *  @return True if *this is value equal to @p rhs and false
-//      *          otherwise.
-//      *
-//      *  @throw None No throw guarantee.
-//      *
-//      */
-//     bool operator==(const NucleiSubset& rhs) const noexcept;
+    // Deleted to avoid accidental slicing, NucleiView implements them for user
+    ///@{
+    NucleiSubset(NucleiSubset&&)                     = delete;
+    NucleiSubset& operator=(const NucleiSubset& rhs) = delete;
+    NucleiSubset& operator=(NucleiSubset&& rhs)      = delete;
+    ///@}
 
-//     /** @brief Does *this contain state?
-//      *
-//      *  For a NucleiSubset object to be null it has to not be associated with
-//      *  a supersystem (in which case it also does not have any nuclei).
-//      *
-//      *  @return True if *this is null and false otherwise.
-//      *
-//      *  @throw None No throw guarantee.
-//      */
-//     bool is_null() const noexcept { return !static_cast<bool>(m_nuclei_); }
+    /** @brief Determines if *this is value equal to @p rhs.
+     *
+     *  We define two NucleiSubset objects as being value equal if they both
+     *  alias Nuclei objects which are value equal.
+     *
+     *  @param[in] rhs The NucleiSubset we are comparing to.
+     *
+     *  @return True if *this is value equal to @p rhs and false
+     *          otherwise.
+     *
+     *  @throw None No throw guarantee.
+     *
+     */
+    bool operator==(const NucleiSubset& rhs) const noexcept;
 
-// protected:
-//     /// Implementes clone
-//     pimpl_pointer clone_() const override {
-//         return std::make_unique<NucleiSubset>(*this);
-//     }
+protected:
+    /// Implementes clone
+    pimpl_pointer clone_() const override {
+        return std::make_unique<NucleiSubset>(*this);
+    }
 
-//     /// Implements getting a mutable Nucleus
-//     reference get_nuke_(size_type i) override {
-//         return reference();
-//         // return (*m_nuclei_)[m_members_[i]];
-//     }
+    /// Implements getting a mutable Nucleus
+    reference get_nuke_(size_type i) override {
+        return m_nuclei_[m_members_[i]];
+    }
 
-//     /// Implements getting a read-only Nucleus
-//     const_reference get_nuke_(size_type i) const override {
-//         return std::as_const(*m_nuclei_)[m_members_[i]];
-//     }
+    /// Implements getting a read-only Nucleus
+    const_reference get_nuke_(size_type i) const override {
+        return m_nuclei_[m_members_[i]];
+    }
 
-//     /// Impelments size
-//     size_type size_() const noexcept override { return m_members_.size(); }
+    /// Impelments size
+    size_type size_() const noexcept override { return m_members_.size(); }
 
-//     /// Implements are_equal
-//     bool are_equal_(const base_type& rhs) const noexcept override {
-//         auto prhs = dynamic_cast<const NucleiSubset*>(&rhs);
-//         if(prhs == nullptr) return false;
-//         return (*this) == (*prhs);
-//     }
+    /// Implements are_equal
+    bool are_equal_(const base_type& rhs) const noexcept override {
+        return base_type::template are_equal_impl_<NucleiSubset>(rhs);
+    }
 
-// private:
-//     /// The full set of nuclei
-//     nuclei_pointer m_nuclei_;
+private:
+    /// The full set of nuclei
+    parent_type m_nuclei_;
 
-//     /// The indices in *this
-//     std::vector<size_type> m_members_;
-// };
+    /// The indices in *this
+    member_list_type m_members_;
+};
 
-// //
-// -----------------------------------------------------------------------------
-// // -- Implementations
-// //
-// -----------------------------------------------------------------------------
+// -- Implementations ----------------------------------------------------------
 
-// template<typename NucleiType>
-// inline bool NucleiSubset<NucleiType>::operator==(
-//   const NucleiSubset& rhs) const noexcept {
-//     if(m_members_ != rhs.m_members_) return false;
+template<typename NucleiType>
+inline bool NucleiSubset<NucleiType>::operator==(
+  const NucleiSubset& rhs) const noexcept {
+    if(this->size() != rhs.size()) return false;
+    if(this->size() == 0) return true;
 
-//     // Try to avoid comparing the Nuclei by checking for the same address
-//     if(m_nuclei_ == rhs.m_nuclei_) return true;
+    // If supersystems are the same just compare the members arrays
+    if(m_nuclei_ == rhs.m_nuclei_) { return m_members_ == rhs.m_members_; }
 
-//     // Above works if they're both null, now see if only one is null
-//     if(is_null() || rhs.is_null()) return false;
+    // different supersystems means we need to compare the values one by one
+    for(size_type i = 0; i < this->size(); ++i)
+        if(this->get_nuke(i) != rhs.get_nuke(i)) return false;
 
-//     // Both are non-null, so compare the Nuclei
-//     return *m_nuclei_ == *rhs.m_nuclei_;
-// }
+    return true;
+}
 
-// } // namespace chemist::detail_
+} // namespace chemist::detail_

--- a/src/chemist/chemical_system/nucleus/nuclei_view/detail_/nuclei_view_pimpl.hpp
+++ b/src/chemist/chemical_system/nucleus/nuclei_view/detail_/nuclei_view_pimpl.hpp
@@ -32,13 +32,13 @@ namespace chemist::detail_ {
 template<typename NucleiType>
 class NucleiViewPIMPL {
 private:
-    /// Type *this implements
-    using parent_type = NucleiView<NucleiType>;
-
     /// Type of *this
     using my_type = NucleiViewPIMPL<NucleiType>;
 
 public:
+    /// Type *this implements
+    using parent_type = NucleiView<NucleiType>;
+
     /// Type nuclei_view_type is a view of
     using nuclei_type = typename parent_type::nuclei_type;
 

--- a/src/chemist/chemical_system/nucleus/nuclei_view/nuclei_view.cpp
+++ b/src/chemist/chemical_system/nucleus/nuclei_view/nuclei_view.cpp
@@ -43,6 +43,11 @@ NUCLEI_VIEW::NucleiView(charges_reference charges, name_pointer pnames,
   NucleiView(std::make_unique<detail_::ContiguousNucleiView<NucleiType>>(
     charges, pnames, patomic_numbers, pmasses)) {}
 
+TPARAMS
+NUCLEI_VIEW::NucleiView(NucleiView supersystem, member_list_type members) :
+  NucleiView(std::make_unique<detail_::NucleiSubset<NucleiType>>(
+    std::move(supersystem), std::move(members))) {}
+
 TPARAMS NUCLEI_VIEW::NucleiView(pimpl_pointer pimpl) noexcept :
   m_pimpl_(std::move(pimpl)) {}
 

--- a/tests/cxx/unit_tests/chemical_system/nucleus/nuclei_view/detail_/nuclei_subset.cpp
+++ b/tests/cxx/unit_tests/chemical_system/nucleus/nuclei_view/detail_/nuclei_subset.cpp
@@ -1,162 +1,151 @@
-// /*
-//  * Copyright 2023 NWChemEx-Project
-//  *
-//  * Licensed under the Apache License, Version 2.0 (the "License");
-//  * you may not use this file except in compliance with the License.
-//  * You may obtain a copy of the License at
-//  *
-//  * http://www.apache.org/licenses/LICENSE-2.0
-//  *
-//  * Unless required by applicable law or agreed to in writing, software
-//  * distributed under the License is distributed on an "AS IS" BASIS,
-//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  * See the License for the specific language governing permissions and
-//  * limitations under the License.
-//  */
+/*
+ * Copyright 2023 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-// #include <catch2/catch.hpp>
-// #include
-// <chemist/chemical_system/nucleus/nuclei_view/detail_/nuclei_subset.hpp>
+#include <catch2/catch.hpp>
+#include <chemist/chemical_system/nucleus/nuclei_view/detail_/nuclei_subset.hpp>
 
-// using namespace chemist::detail_;
+using namespace chemist::detail_;
 
-// TEST_CASE("NucleiSubset") {
-//     using nuclei_type = chemist::Nuclei;
-//     using pimpl_type  = NucleiSubset<nuclei_type>;
-//     using const_pimpl = NucleiSubset<const nuclei_type>;
+template<typename NucleiType>
+void test_nuclei_subset() {
+    using pimpl_type       = NucleiSubset<NucleiType>;
+    using view_type        = typename pimpl_type::parent_type;
+    using nucleus_type     = typename pimpl_type::value_type;
+    using member_list_type = typename pimpl_type::member_list_type;
 
-//     // Create some Nucleus objects. Objects do not need to be physical, just
-//     // distinct.
-//     using nucleus_type = typename pimpl_type::value_type;
+    // Create some Nucleus objects. Objects do not need to be physical, just
+    // distinct.
+    nucleus_type h0("H", 1ul, 1.0, 4.0, 7.0, 0.0, 3.0);
+    nucleus_type h1("H", 1ul, 2.0, 5.0, 8.0, 1.0, 4.0);
+    nucleus_type h2("H", 1ul, 3.0, 6.0, 9.0, 2.0, 5.0);
 
-//     nucleus_type h0("H", 1ul, 0.0, 1.0, 2.0, 3.0, 4.0);
-//     nucleus_type h1("H", 1ul, 0.0, 5.0, 6.0, 7.0, 8.0);
-//     nucleus_type h2("H", 1ul, 0.0, 9.0, 8.0, 7.0, 6.0);
+    NucleiType nuclei{h0, h1, h2};
+    view_type supersys(nuclei);
 
-//     // Create a Nuclei object
-//     auto pnuclei = std::make_shared<nuclei_type>(nuclei_type{h0, h1, h2});
+    // Create pimpl_type objects
+    pimpl_type defaulted;
 
-//     // Create pimpl_type objects
-//     using size_type = typename pimpl_type::size_type;
-//     pimpl_type defaulted;
-//     const_pimpl const_defaulted;
+    member_list_type indices{1, 2}, no_indices;
+    pimpl_type empty(supersys, no_indices);
+    pimpl_type has_values(supersys, indices);
 
-//     std::vector<size_type> indices{1, 2};
-//     pimpl_type has_values(pnuclei, indices.begin(), indices.end());
-//     const_pimpl const_has_values(pnuclei, indices.begin(), indices.end());
+    SECTION("Ctors") {
+        SECTION("Default") { REQUIRE(defaulted.size() == 0); }
 
-//     SECTION("Ctors") {
-//         SECTION("Default") {
-//             REQUIRE(defaulted.size() == 0);
-//             REQUIRE(defaulted.is_null());
+        SECTION("value") {
+            REQUIRE(empty.size() == 0);
 
-//             REQUIRE(const_defaulted.size() == 0);
-//             REQUIRE(const_defaulted.is_null());
-//         }
+            REQUIRE(has_values.size() == 2);
+            REQUIRE(has_values.get_nuke(0) == supersys[1]);
+            REQUIRE(has_values.get_nuke(1) == supersys[2]);
+        }
 
-//         SECTION("value") {
-//             REQUIRE_FALSE(has_values.is_null());
-//             REQUIRE(has_values.size() == 2);
-//             REQUIRE(has_values.get_nuke(0) == (*pnuclei)[1]);
-//             REQUIRE(has_values.get_nuke(1) == (*pnuclei)[2]);
+        SECTION("copy") {
+            pimpl_type defaulted_copy(defaulted);
+            REQUIRE(defaulted_copy.size() == 0);
 
-//             REQUIRE_FALSE(const_has_values.is_null());
-//             REQUIRE(const_has_values.size() == 2);
-//             REQUIRE(const_has_values.get_nuke(0) == (*pnuclei)[1]);
-//             REQUIRE(const_has_values.get_nuke(1) == (*pnuclei)[2]);
-//         }
+            pimpl_type empty_copy(empty);
+            REQUIRE(empty_copy.size() == 0);
 
-//         SECTION("copy") {
-//             pimpl_type defaulted_copy(defaulted);
-//             REQUIRE(defaulted_copy.size() == 0);
-//             REQUIRE(defaulted.is_null());
+            pimpl_type has_values_copy(has_values);
+            REQUIRE(has_values_copy.size() == 2);
+            REQUIRE(has_values_copy.get_nuke(0) == supersys[1]);
+            REQUIRE(has_values_copy.get_nuke(1) == supersys[2]);
+        }
+    }
 
-//             const_pimpl const_defaulted_copy(const_defaulted);
-//             REQUIRE(const_defaulted_copy.size() == 0);
-//             REQUIRE(const_defaulted.is_null());
+    SECTION("clone") {
+        auto pdefaulted = defaulted.clone();
+        REQUIRE(pdefaulted->size() == 0);
 
-//             pimpl_type has_values_copy(has_values);
-//             REQUIRE_FALSE(has_values_copy.is_null());
-//             REQUIRE(has_values_copy.size() == 2);
-//             REQUIRE(has_values_copy.get_nuke(0) == (*pnuclei)[1]);
-//             REQUIRE(has_values_copy.get_nuke(1) == (*pnuclei)[2]);
+        auto pempty = empty.clone();
+        REQUIRE(pempty->size() == 0);
 
-//             const_pimpl const_has_values_copy(const_has_values);
-//             REQUIRE_FALSE(const_has_values_copy.is_null());
-//             REQUIRE(const_has_values_copy.size() == 2);
-//             REQUIRE(const_has_values_copy.get_nuke(0) == (*pnuclei)[1]);
-//             REQUIRE(const_has_values_copy.get_nuke(1) == (*pnuclei)[2]);
-//         }
-//     }
+        auto phas_value = has_values.clone();
+        REQUIRE(phas_value->size() == 2);
+        REQUIRE(phas_value->get_nuke(0) == supersys[1]);
+        REQUIRE(phas_value->get_nuke(1) == supersys[2]);
+    }
 
-//     SECTION("clone") {
-//         auto pdefaulted = defaulted.clone();
-//         REQUIRE(pdefaulted->size() == 0);
+    SECTION("get_nuke") {
+        REQUIRE(has_values.get_nuke(0) == supersys[1]);
+        REQUIRE(has_values.get_nuke(1) == supersys[2]);
 
-//         auto pconst_defaulted = const_defaulted.clone();
-//         REQUIRE(pconst_defaulted->size() == 0);
+        // If nuclei are mutable make sure we can mutate them
+        using no_cv = std::remove_cv_t<NucleiType>;
+        if constexpr(std::is_same_v<NucleiType, no_cv>) {
+            has_values.get_nuke(0) = h0;
+            REQUIRE(has_values.get_nuke(0) == h0);
+            REQUIRE(supersys[1] == h0);
+        }
+    }
 
-//         auto phas_value = has_values.clone();
-//         REQUIRE(phas_value->size() == 2);
-//         REQUIRE(phas_value->get_nuke(0) == (*pnuclei)[1]);
-//         REQUIRE(phas_value->get_nuke(1) == (*pnuclei)[2]);
+    SECTION("get_nuke()const") {
+        REQUIRE(std::as_const(has_values).get_nuke(0) == supersys[1]);
+        REQUIRE(std::as_const(has_values).get_nuke(1) == supersys[2]);
+    }
 
-//         auto pconst_has_value = const_has_values.clone();
-//         REQUIRE(pconst_has_value->size() == 2);
-//         REQUIRE(pconst_has_value->get_nuke(0) == (*pnuclei)[1]);
-//         REQUIRE(pconst_has_value->get_nuke(1) == (*pnuclei)[2]);
-//     }
+    SECTION("size") {
+        REQUIRE(defaulted.size() == 0);
+        REQUIRE(empty.size() == 0);
+        REQUIRE(has_values.size() == 2);
+    }
 
-//     SECTION("get_nuke") {
-//         REQUIRE(has_values.get_nuke(0) == (*pnuclei)[1]);
-//         REQUIRE(has_values.get_nuke(1) == (*pnuclei)[2]);
+    SECTION("operator==") {
+        // Defaulted == defaulted
+        REQUIRE(defaulted == pimpl_type{});
 
-//         REQUIRE(const_has_values.get_nuke(0) == (*pnuclei)[1]);
-//         REQUIRE(const_has_values.get_nuke(1) == (*pnuclei)[2]);
-//     }
+        // Defaulted vs. empty
+        REQUIRE(defaulted == empty);
 
-//     SECTION("get_nuke()const") {
-//         REQUIRE(std::as_const(has_values).get_nuke(0) == (*pnuclei)[1]);
-//         REQUIRE(std::as_const(has_values).get_nuke(1) == (*pnuclei)[2]);
+        // Defaulted != non-default
+        REQUIRE_FALSE(defaulted == has_values);
 
-//         REQUIRE(std::as_const(const_has_values).get_nuke(0) ==
-//         (*pnuclei)[1]); REQUIRE(std::as_const(const_has_values).get_nuke(1)
-//         == (*pnuclei)[2]);
-//     }
+        // Empty vs. empty
+        pimpl_type empty2(supersys, no_indices);
+        REQUIRE(empty == empty2);
 
-//     SECTION("size") {
-//         REQUIRE(defaulted.size() == 0);
-//         REQUIRE(const_defaulted.size() == 0);
+        // Empty vs. non-empty
+        REQUIRE_FALSE(empty == has_values);
 
-//         REQUIRE(has_values.size() == 2);
-//         REQUIRE(const_has_values.size() == 2);
-//     }
+        // Same everything
+        pimpl_type has_values2(supersys, indices);
+        REQUIRE(has_values == has_values2);
 
-//     SECTION("operator==") {
-//         // Defaulted == defaulted
-//         REQUIRE(defaulted == pimpl_type{});
+        // Different instance of same supersystem
+        view_type supersys2(nuclei);
+        pimpl_type has_values3(supersys2, indices);
+        REQUIRE(has_values == has_values3);
 
-//         // Defaulted != non-default
-//         REQUIRE_FALSE(defaulted == has_values);
+        // Different supersystem (same atoms)
+        nucleus_type h3("H", 1ul, 0.0, 1.1, 2.2, 3.3, 4.4);
+        NucleiType nuclei2{h3, h1, h2};
+        view_type supersys3(nuclei2);
+        pimpl_type diff_ss(supersys3, indices);
+        REQUIRE(has_values == diff_ss);
 
-//         // Same everything
-//         pimpl_type has_values2(pnuclei, indices.begin(), indices.end());
-//         REQUIRE(has_values == has_values2);
+        // Different atoms
+        member_list_type indices2{0, 1};
+        pimpl_type diff_atoms(supersys, indices2);
+        REQUIRE_FALSE(has_values == diff_atoms);
+    }
+}
 
-//         // Different instance of same supersystem
-//         auto pnuclei1 = std::make_shared<nuclei_type>(nuclei_type{h0, h1,
-//         h2}); pimpl_type has_values3(pnuclei1, indices.begin(),
-//         indices.end()); REQUIRE(has_values == has_values3);
+TEST_CASE("NucleiSubset<Nuclei>") { test_nuclei_subset<chemist::Nuclei>(); }
 
-//         // Different supersystem (same atoms)
-//         nucleus_type h3("H", 1ul, 0.0, 1.1, 2.2, 3.3, 4.4);
-//         auto pnuclei2 = std::make_shared<nuclei_type>(nuclei_type{h3, h1,
-//         h2}); pimpl_type diff_ss(pnuclei2, indices.begin(), indices.end());
-//         REQUIRE_FALSE(has_values == diff_ss);
-
-//         // Different atoms
-//         std::vector<size_type> indices2{0, 1};
-//         pimpl_type diff_atoms(pnuclei, indices2.begin(), indices2.end());
-//         REQUIRE_FALSE(has_values == diff_atoms);
-//     }
-// }
+TEST_CASE("NucleiSubset<const Nuclei>") {
+    test_nuclei_subset<const chemist::Nuclei>();
+}

--- a/tests/cxx/unit_tests/chemical_system/nucleus/nuclei_view/nuclei_view.cpp
+++ b/tests/cxx/unit_tests/chemical_system/nucleus/nuclei_view/nuclei_view.cpp
@@ -35,9 +35,10 @@ using namespace chemist;
 
 template<typename NucleiType>
 void test_nuclei_view() {
-    using set_type   = NucleiType;
-    using value_type = typename set_type::value_type;
-    using view_type  = NucleiView<set_type>;
+    using set_type         = NucleiType;
+    using value_type       = typename set_type::value_type;
+    using view_type        = NucleiView<set_type>;
+    using member_list_type = typename view_type::member_list_type;
 
     value_type n0("H", 1ul, 0.0, 1.0, 2.0, 3.0, 4.0);
     value_type n1("He", 2ul, 4.0, 5.0, 6.0, 7.0, 5.0);
@@ -72,6 +73,25 @@ void test_nuclei_view() {
             REQUIRE(pointers.size() == 2);
             REQUIRE(pointers[0] == n0);
             REQUIRE(pointers[1] == n1);
+        }
+
+        SECTION("Subset") {
+            view_type empty_subset(value, member_list_type{});
+            REQUIRE(empty_subset.size() == 0);
+
+            view_type proper_subset(value, member_list_type{1});
+            REQUIRE(proper_subset.size() == 1);
+            REQUIRE(proper_subset[0] == n1);
+
+            view_type subset(value, member_list_type{0, 1});
+            REQUIRE(subset.size() == 2);
+            REQUIRE(subset[0] == n0);
+            REQUIRE(subset[1] == n1);
+
+            view_type reverse_subset(value, member_list_type{1, 0});
+            REQUIRE(reverse_subset.size() == 2);
+            REQUIRE(reverse_subset[0] == n1);
+            REQUIRE(reverse_subset[1] == n0);
         }
 
         SECTION("Copy") {
@@ -241,6 +261,12 @@ void test_nuclei_view() {
         // operator!=(Nuclei) works)
         REQUIRE_FALSE(set_type{} != defaulted);
         REQUIRE(set_type{} != value);
+    }
+
+    SECTION("Can mix and match PIMPLs") {
+        view_type subset(value, member_list_type{0, 1});
+
+        REQUIRE(subset == value);
     }
 }
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
This adds a new backend to the `NucleiView` class which preserves the supersystem/subsystem relationship between the `Nuclei` objects aliased by two `NucleiView` objects.

**TODOs**
None. This is r2g.
