### PR TITLE
Clang patch

### DIFF
--- a/src/chemist/chemical_system/molecule/molecule_class.cpp
+++ b/src/chemist/chemical_system/molecule/molecule_class.cpp
@@ -175,7 +175,14 @@ bool operator==(const Molecule& lhs, const Molecule& rhs) noexcept {
     if(lhs.charge() != rhs.charge()) return false;
     if(lhs.multiplicity() != rhs.multiplicity()) return false;
 
-    return std::equal(lhs.begin(), lhs.end(), rhs.begin());
+    // LLVM Clang doesn't like this at the moment.
+    // TODO: figure out why Clang doesn't work with this.
+    // return std::equal(lhs.begin(), lhs.end(), rhs.begin());
+    
+    for(auto i = 0; i < lhs.size(); ++i) {
+        if(lhs[i] != rhs[i]) return false;
+    }
+    return true;
 }
 
 } // namespace chemist

--- a/src/chemist/chemical_system/molecule/molecule_class.cpp
+++ b/src/chemist/chemical_system/molecule/molecule_class.cpp
@@ -178,7 +178,7 @@ bool operator==(const Molecule& lhs, const Molecule& rhs) noexcept {
     // LLVM Clang doesn't like this at the moment.
     // TODO: figure out why Clang doesn't work with this.
     // return std::equal(lhs.begin(), lhs.end(), rhs.begin());
-    
+
     for(auto i = 0; i < lhs.size(); ++i) {
         if(lhs[i] != rhs[i]) return false;
     }


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
LLVM takes issue with our usage of `std::equal` for some reason. This is a work around for it.