### PR TITLE
Ability to get fragment indices

### DIFF
--- a/include/chemist/fragmenting/fragmented_nuclei.hpp
+++ b/include/chemist/fragmenting/fragmented_nuclei.hpp
@@ -288,6 +288,23 @@ public:
      */
     void insert(nucleus_index_set nuclei);
 
+    /** @brief Returns the indices for the nuclei in the @p i -th fragment.
+     *
+     *  The `operator[]` and `at` methods return fragments as objects. Sometimes
+     *  we want to just know the offsets of the elements in the fragments. This
+     *  method can be used to retrieve the set of offsets for the @p i -th
+     *  fragment.
+     *
+     *  @param[in] i The offset of the fragment whose indices we want. @p i
+     *               must be in the range [0, size()).
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the result.
+     *                        Strong throw guarantee.
+     *  @throw std::out_of_range if @p i is not in the range [0, size()). Strong
+     *                           throw guarantee.
+     */
+    nucleus_index_set nuclear_indices(size_type i) const;
+
     /** @brief Provides access to the caps in *this.
      *
      *  When fragmenting large, covalently bonded systems we often must sever

--- a/src/chemist/fragmenting/fragmented_nuclei.cpp
+++ b/src/chemist/fragmenting/fragmented_nuclei.cpp
@@ -185,6 +185,13 @@ void FRAGMENTED_NUCLEI::insert(nucleus_index_set nuclei) {
 }
 
 TPARAMS
+typename FRAGMENTED_NUCLEI::nucleus_index_set
+FRAGMENTED_NUCLEI::nuclear_indices(size_type i) const {
+    if(i < size_()) return m_pimpl_->frag(i);
+    throw std::out_of_range(std::to_string(i) + " >= size()");
+}
+
+TPARAMS
 typename FRAGMENTED_NUCLEI::cap_set_reference FRAGMENTED_NUCLEI::cap_set() {
     if(!has_pimpl_()) std::make_unique<pimpl_type>().swap(m_pimpl_);
     return m_pimpl_->cap_set();

--- a/src/python/fragmenting/export_fragmented_nuclei.cpp
+++ b/src/python/fragmenting/export_fragmented_nuclei.cpp
@@ -17,7 +17,7 @@
 #include "export_fragmenting.hpp"
 #include <chemist/fragmenting/fragmented_nuclei.hpp>
 #include <pybind11/operators.h>
-
+#include <pybind11/stl.h>
 namespace chemist::fragmenting {
 
 void export_fragmented_nuclei(python_module_reference m) {
@@ -76,6 +76,7 @@ void export_fragmented_nuclei(python_module_reference m) {
            pybind11::arg("nucleus_to_fragment"),
            pybind11::arg("caps") = cap_set_type{})
       .def("insert", insert_index)
+      .def("nuclear_indices", &fragmented_nuclei_type::nuclear_indices)
       .def("cap_set", cap_set, ka)
       .def("add_cap", &fragmented_nuclei_type::add_cap)
       .def("supersystem", supersystem, ka)

--- a/tests/cxx/unit_tests/fragmenting/fragmented_nuclei.cpp
+++ b/tests/cxx/unit_tests/fragmenting/fragmented_nuclei.cpp
@@ -279,6 +279,17 @@ TEMPLATE_LIST_TEST_CASE("FragmentedNuclei", "", types2test) {
         REQUIRE(no_frags[0] == corr0);
     }
 
+    SECTION("nuclear_indices") {
+        REQUIRE_THROWS_AS(empty_set.nuclear_indices(0), std::out_of_range);
+
+        REQUIRE(disjoint_no_caps.nuclear_indices(0) == i0);
+        REQUIRE(disjoint_no_caps.nuclear_indices(1) == i1);
+        REQUIRE(disjoint_no_caps.nuclear_indices(2) == i2);
+
+        REQUIRE(nondisjoint_caps.nuclear_indices(0) == i01);
+        REQUIRE(nondisjoint_caps.nuclear_indices(1) == i12);
+    }
+
     SECTION("cap_set()") {
         REQUIRE(no_frags.cap_set() == cap_set_type{});
         REQUIRE(nondisjoint_caps.cap_set() == caps);

--- a/tests/python/unit_tests/fragmenting/test_fragmented_nuclei.py
+++ b/tests/python/unit_tests/fragmenting/test_fragmented_nuclei.py
@@ -73,6 +73,16 @@ class TestFragmentedNuclei(unittest.TestCase):
         self.assertEqual(self.no_frags.size(), 2)
         self.assertEqual(self.no_frags.at(1), self.frag12)
 
+    def test_nuclear_indices(self):
+        self.assertRaises(IndexError, self.no_frags.nuclear_indices, 0)
+
+        self.assertEqual(self.disjoint.nuclear_indices(0), [0])
+        self.assertEqual(self.disjoint.nuclear_indices(1), [1])
+        self.assertEqual(self.disjoint.nuclear_indices(2), [2])
+
+        self.assertEqual(self.nondisjoint_caps.nuclear_indices(0), [0, 1])
+        self.assertEqual(self.nondisjoint_caps.nuclear_indices(1), [1, 2])
+
     def test_cap_set(self):
         self.assertEqual(self.defaulted.cap_set(), self.empty_caps)
         self.assertEqual(self.no_frags.cap_set(), self.empty_caps)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Previously `FragmentedNuclei` (and the other classes in the hierarchy) could only return fragments as objects. For mapping purposes it's usually much easier to treat fragments as sets of offsets. This PR adds to `FragmentedNuclei` a member method `nuclear_indices` which will return the indices of the nuclei in the specified fragment.

**TODOs**
None. R2G.
