### PR TITLE
adds the ability to access fragments

### DIFF
--- a/include/chemist/fragmenting/fragmented_chemical_system.hpp
+++ b/include/chemist/fragmenting/fragmented_chemical_system.hpp
@@ -172,6 +172,30 @@ public:
     ~FragmentedChemicalSystem() noexcept;
 
     // -------------------------------------------------------------------------
+    // -- Getters and Setters
+    // -------------------------------------------------------------------------
+
+    /** @brief Returns the FragmentedMolecule piece of *this
+     *
+     *
+     *  @return A mutable reference to FragmentedMolecule piece of *this.
+     *
+     *  @throw std::runtime_error if *this does not have a PIMPL. Strong throw
+     *                            guarantee.
+     */
+    fragmented_molecule_type& fragmented_molecule();
+
+    /** @brief Returns the FragmentedMolecule piece of *this
+     *
+     *
+     *  @return A read-only reference to FragmentedMolecule piece of *this.
+     *
+     *  @throw std::runtime_error if *this does not have a PIMPL. Strong throw
+     *                            guarantee.
+     */
+    const fragmented_molecule_type& fragmented_molecule() const;
+
+    // -------------------------------------------------------------------------
     // -- Utility methods
     // -------------------------------------------------------------------------
 
@@ -236,6 +260,9 @@ protected:
 private:
     /// Code factorization for determining if *this has a PIMPL
     bool has_pimpl_() const noexcept;
+
+    /// Throws std::runtime_error if *this has no PIMPL
+    void assert_pimpl_() const;
 
     /// The object which actually implements *this
     pimpl_pointer m_pimpl_;

--- a/include/chemist/fragmenting/fragmented_molecule.hpp
+++ b/include/chemist/fragmenting/fragmented_molecule.hpp
@@ -215,6 +215,30 @@ public:
     ~FragmentedMolecule() noexcept;
 
     // -------------------------------------------------------------------------
+    // -- Getters and setters
+    // -------------------------------------------------------------------------
+
+    /** @brief Returns the FragmentedNuclei piece of *this
+     *
+     *
+     *  @return A mutable reference to FragmentedNuclei piece of *this.
+     *
+     *  @throw std::runtime_error if *this does not have a PIMPL. Strong throw
+     *                            guarantee.
+     */
+    fragmented_nuclei_type& fragmented_nuclei();
+
+    /** @brief Returns the FragmentedNuclei piece of *this
+     *
+     *
+     *  @return A read-onlyreference to FragmentedNuclei piece of *this.
+     *
+     *  @throw std::runtime_error if *this does not have a PIMPL. Strong throw
+     *                            guarantee.
+     */
+    const fragmented_nuclei_type& fragmented_nuclei() const;
+
+    // -------------------------------------------------------------------------
     // -- Utility methods
     // -------------------------------------------------------------------------
 
@@ -278,6 +302,9 @@ protected:
 private:
     /// Code factorization for determining if *this has a PIMPL or not
     bool has_pimpl_() const noexcept;
+
+    /// Throws std::runtime_error if *this has no PIMPL
+    void assert_pimpl_() const;
 
     /// The object which actually implements *this
     pimpl_pointer m_pimpl_;

--- a/src/chemist/fragmenting/fragmented_chemical_system.cpp
+++ b/src/chemist/fragmenting/fragmented_chemical_system.cpp
@@ -59,6 +59,9 @@ public:
         return const_supersystem_reference(m_frags_.supersystem());
     }
 
+    auto& frags() { return m_frags_; }
+    const auto& frags() const { return m_frags_; }
+
 private:
     fragmented_molecule_type m_frags_;
 };
@@ -102,6 +105,24 @@ FRAGMENTED_CHEMICAL_SYSTEM& FRAGMENTED_CHEMICAL_SYSTEM::operator=(
 
 TPARAMS FRAGMENTED_CHEMICAL_SYSTEM::~FragmentedChemicalSystem() noexcept =
   default;
+
+// -----------------------------------------------------------------------------
+// -- Getters and setters
+// -----------------------------------------------------------------------------
+
+TPARAMS
+typename FRAGMENTED_CHEMICAL_SYSTEM::fragmented_molecule_type&
+FRAGMENTED_CHEMICAL_SYSTEM::fragmented_molecule() {
+    assert_pimpl_();
+    return m_pimpl_->frags();
+}
+
+TPARAMS
+const typename FRAGMENTED_CHEMICAL_SYSTEM::fragmented_molecule_type&
+FRAGMENTED_CHEMICAL_SYSTEM::fragmented_molecule() const {
+    assert_pimpl_();
+    return std::as_const(*m_pimpl_).frags();
+}
 
 // -----------------------------------------------------------------------------
 // -- Utility methods
@@ -172,6 +193,12 @@ FRAGMENTED_CHEMICAL_SYSTEM::supersystem_() const {
 TPARAMS
 bool FRAGMENTED_CHEMICAL_SYSTEM::has_pimpl_() const noexcept {
     return static_cast<bool>(m_pimpl_);
+}
+
+TPARAMS
+void FRAGMENTED_CHEMICAL_SYSTEM::assert_pimpl_() const {
+    if(has_pimpl_()) return;
+    throw std::runtime_error("FragmentedChemicalSystem has no PIMPL");
 }
 
 #undef FRAGMENTED_CHEMICAL_SYSTEM

--- a/src/chemist/fragmenting/fragmented_molecule.cpp
+++ b/src/chemist/fragmenting/fragmented_molecule.cpp
@@ -92,6 +92,10 @@ public:
                                          m_charges_, m_multiplicities_);
     }
 
+    auto& frags() { return m_frags_; }
+
+    const auto& frags() const { return m_frags_; }
+
 private:
     fragmented_nuclei_type m_frags_;
 
@@ -192,6 +196,24 @@ TPARAMS
 FRAGMENTED_MOLECULE::~FragmentedMolecule() noexcept = default;
 
 // -----------------------------------------------------------------------------
+// -- Getters and setters
+// -----------------------------------------------------------------------------
+
+TPARAMS
+typename FRAGMENTED_MOLECULE::fragmented_nuclei_type&
+FRAGMENTED_MOLECULE::fragmented_nuclei() {
+    assert_pimpl_();
+    return m_pimpl_->frags();
+}
+
+TPARAMS
+const typename FRAGMENTED_MOLECULE::fragmented_nuclei_type&
+FRAGMENTED_MOLECULE::fragmented_nuclei() const {
+    assert_pimpl_();
+    return std::as_const(*m_pimpl_).frags();
+}
+
+// -----------------------------------------------------------------------------
 // -- Utility methods
 // -----------------------------------------------------------------------------
 
@@ -258,6 +280,12 @@ FRAGMENTED_MOLECULE::supersystem_() const {
 TPARAMS
 bool FRAGMENTED_MOLECULE::has_pimpl_() const noexcept {
     return static_cast<bool>(m_pimpl_);
+}
+
+TPARAMS
+void FRAGMENTED_MOLECULE::assert_pimpl_() const {
+    if(has_pimpl_()) return;
+    throw std::runtime_error("FragmentedMolecule object has no PIMPL");
 }
 
 #undef FRAGMENTED_MOLECULE

--- a/tests/cxx/unit_tests/fragmenting/fragmented_chemical_system.cpp
+++ b/tests/cxx/unit_tests/fragmenting/fragmented_chemical_system.cpp
@@ -70,6 +70,18 @@ TEMPLATE_LIST_TEST_CASE("FragmentedChemicalSystem", "", types2check) {
         test_chemist::test_copy_and_move(defaulted, empty, value);
     }
 
+    SECTION("fragmented_molecule()") {
+        REQUIRE_THROWS_AS(defaulted.fragmented_molecule(), std::runtime_error);
+        REQUIRE(value.fragmented_molecule() == value_frags);
+    }
+
+    SECTION("fragmented_molecule() const") {
+        const auto& const_defaulted = std::as_const(defaulted);
+        using error_t               = std::runtime_error;
+        REQUIRE_THROWS_AS(const_defaulted.fragmented_molecule(), error_t);
+        REQUIRE(std::as_const(value).fragmented_molecule() == value_frags);
+    }
+
     SECTION("supersystem()") {
         REQUIRE(defaulted.supersystem() == empty_cs);
         REQUIRE(empty.supersystem() == empty_cs);

--- a/tests/cxx/unit_tests/fragmenting/fragmented_molecule.cpp
+++ b/tests/cxx/unit_tests/fragmenting/fragmented_molecule.cpp
@@ -118,6 +118,18 @@ TEMPLATE_LIST_TEST_CASE("FragmentedMolecule", "", types2test) {
         }
     }
 
+    SECTION("fragmented_nuclei()") {
+        REQUIRE_THROWS_AS(defaulted.fragmented_nuclei(), std::runtime_error);
+        REQUIRE(value.fragmented_nuclei() == frags);
+    }
+
+    SECTION("fragmented_nuclei() const") {
+        const auto& const_defaulted = std::as_const(defaulted);
+        using error_t               = std::runtime_error;
+        REQUIRE_THROWS_AS(const_defaulted.fragmented_nuclei(), error_t);
+        REQUIRE(std::as_const(value).fragmented_nuclei() == frags);
+    }
+
     SECTION("operator[]") {
         REQUIRE(value_frags[0] == frag0);
         REQUIRE(value_frags[1] == frag1);


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
`FragmentedChemicalSystem` did not let you access the `FragmentedMolecule` inside it. Similarly `FragmentedMolecule` did not expose the `FragmentedNuclei` in it. This PR fixes that.

**TODOs**
None. R2g.
