### PR TITLE
Better Atom Printing

### DIFF
--- a/src/chemist/chemical_system/molecule/atom.cpp
+++ b/src/chemist/chemical_system/molecule/atom.cpp
@@ -29,8 +29,8 @@ bool operator==(const Atom& lhs, const Atom& rhs) noexcept {
 }
 
 std::ostream& operator<<(std::ostream& os, const Atom& ai) {
-    os << ai.name() << std::fixed << std::setprecision(15);
-    for(auto c = 0; c < 3; ++c) os << " " << ai.coord(c);
+    os << "nelectrons : " << ai.n_electrons() << "," << std::endl;
+    os << ai.nucleus();
     return os;
 }
 } // namespace chemist

--- a/tests/cxx/unit_tests/chemical_system/molecule/atom.cpp
+++ b/tests/cxx/unit_tests/chemical_system/molecule/atom.cpp
@@ -129,11 +129,18 @@ TEST_CASE("Atom Class") {
     }
 
     SECTION("Printing") {
-        std::string corr =
-          "H 1.000000000000000 2.000000000000000 3.000000000000000";
+        std::stringstream corr;
+        corr << "nelectrons : 1," << std::endl;
+        corr << "name : H," << std::endl;
+        corr << "atomic number : 1," << std::endl;
+        corr << "mass : 0," << std::endl;
+        corr << "charge : 1," << std::endl;
+        corr << "x : 1," << std::endl;
+        corr << "y : 2," << std::endl;
+        corr << "z : 3";
         std::stringstream ss;
-        ss << Atom{h, 0ul, 0.0, 1.0, 2.0, 3.0};
-        REQUIRE(ss.str() == corr);
+        ss << Atom{h, 1ul, 0.0, 1.0, 2.0, 3.0};
+        REQUIRE(ss.str() == corr.str());
     }
 
 } // TEST_CASE("Atom Class")

--- a/tests/python/unit_tests/chemical_system/molecule/test_atom.py
+++ b/tests/python/unit_tests/chemical_system/molecule/test_atom.py
@@ -197,12 +197,14 @@ class TestAtom(unittest.TestCase):
         # Default
         self.assertEqual(
             str(self.defaulted),
-            ' 0.000000000000000 0.000000000000000 0.000000000000000')
+            'nelectrons : 0,\nname : ,\natomic number : 0,\nmass : 0,\n' +
+            'charge : 0,\nx : 0,\ny : 0,\nz : 0')
 
         # Has value
         self.assertEqual(
             str(self.h),
-            'H 2.000000000000000 3.000000000000000 4.000000000000000')
+            'nelectrons : 1,\nname : H,\natomic number : 1,\nmass : 1,\n' +
+            'charge : 1,\nx : 2,\ny : 3,\nz : 4')
 
     def setUp(self):
         self.defaulted = chemist.Atom()

--- a/tests/python/unit_tests/chemical_system/molecule/test_molecule.py
+++ b/tests/python/unit_tests/chemical_system/molecule/test_molecule.py
@@ -97,8 +97,10 @@ class TestMolecule(unittest.TestCase):
         # Has value
         self.assertEqual(
             str(self.has_value),
-            ' 0.000000000000000 0.000000000000000 0.000000000000000\nH 2.000000000000000 3.000000000000000 4.000000000000000\n'
-        )
+            'nelectrons : 0,\nname : ,\natomic number : 0,\nmass : 0,\n' +
+            'charge : 0,\nx : 0,\ny : 0,\nz : 0\n' +
+            'nelectrons : 1,\nname : H,\natomic number : 1,\nmass : 1,\n' +
+            'charge : 5,\nx : 2,\ny : 3,\nz : 4\n')
 
     def setUp(self):
         self.defaulted = chemist.Molecule()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
When you printed `Atom` objects it suppressed a lot of state. This PR makes it so the string representation of an `Atom` object looks more like that of a `Nucleus` object.

**TODOs**
None. R2g.
