### PR TITLE
Exposes the Charges piece of Nuclei to Python

### DIFF
--- a/include/chemist/chemical_system/point_charge/charges.hpp
+++ b/include/chemist/chemical_system/point_charge/charges.hpp
@@ -285,6 +285,28 @@ private:
     pimpl_pointer m_pimpl_;
 };
 
+/** @brief Prints a Charges object
+ *
+ *  @tparam T The floating point type.
+ *
+ *  This method simply loops over the PointCharge objects in @p charges
+ *  and prints them.
+ *
+ *  @param[in] os The stream to print to.
+ *  @param[in] charges The object to print out.
+ *
+ *  @return Returns @p os after adding @p charges to it.
+ *  @throw std::ios_base_failure if anything goes wrong while writing. Weak
+ *                               throw guarantee.
+ */
+template<typename T>
+std::ostream& operator<<(std::ostream& os, const Charges<T>& charges) {
+    for(decltype(charges.size()) i = 0; i < charges.size(); i++) {
+        os << charges[i] << std::endl;
+    }
+    return os;
+}
+
 template<typename T>
 template<typename Archive>
 void Charges<T>::save(Archive& ar) const {

--- a/include/chemist/chemical_system/point_charge/point_charge_view.hpp
+++ b/include/chemist/chemical_system/point_charge/point_charge_view.hpp
@@ -139,7 +139,7 @@ public:
                                      std::decay_t<ChargeType2>, ChargeType>>>
     PointChargeView& operator=(ChargeType2&& charge) {
         point_view_type::operator=(std::forward<point_type>(charge));
-        (*m_pq_) = charge.charge();
+        (*m_pq_)                 = charge.charge();
         return *this;
     }
 

--- a/include/chemist/chemical_system/point_charge/point_charge_view.hpp
+++ b/include/chemist/chemical_system/point_charge/point_charge_view.hpp
@@ -248,6 +248,17 @@ bool operator!=(const PointCharge<ChargeType>& lhs,
     return rhs != lhs;
 }
 
+/** @brief Prints a PointChargeView object
+ *
+ *  @tparam ChargeType The charge type.
+ *
+ *  @param[in] os The stream to print to.
+ *  @param[in] q The object to print out.
+ *
+ *  @return Returns @p os after adding @p q to it.
+ *  @throw std::ios_base_failure if anything goes wrong while writing. Weak
+ *                               throw guarantee.
+ */
 template<typename ChargeType>
 std::ostream& operator<<(std::ostream& os,
                          const PointChargeView<ChargeType>& q) {

--- a/include/chemist/chemical_system/point_charge/point_charge_view.hpp
+++ b/include/chemist/chemical_system/point_charge/point_charge_view.hpp
@@ -139,7 +139,7 @@ public:
                                      std::decay_t<ChargeType2>, ChargeType>>>
     PointChargeView& operator=(ChargeType2&& charge) {
         point_view_type::operator=(std::forward<point_type>(charge));
-        (*m_pq_)                 = charge.charge();
+        (*m_pq_) = charge.charge();
         return *this;
     }
 
@@ -246,6 +246,12 @@ template<typename ChargeType, typename ChargeType2>
 bool operator!=(const PointCharge<ChargeType>& lhs,
                 const PointChargeView<ChargeType2>& rhs) {
     return rhs != lhs;
+}
+
+template<typename ChargeType>
+std::ostream& operator<<(std::ostream& os,
+                         const PointChargeView<ChargeType>& q) {
+    return os << q.as_point_charge();
 }
 
 // -- Inline implementations ---------------------------------------------------

--- a/src/python/chemical_system/nucleus/export_nuclei.cpp
+++ b/src/python/chemical_system/nucleus/export_nuclei.cpp
@@ -27,6 +27,7 @@ void export_nuclei(python_module_reference m) {
 
     using nuclei_type      = Nuclei;
     using nuclei_reference = nuclei_type&;
+    using charges_type     = typename nuclei_type::charge_set_type;
     using value_type       = typename nuclei_type::value_type;
     using size_type        = typename nuclei_type::size_type;
 
@@ -39,6 +40,11 @@ void export_nuclei(python_module_reference m) {
             values.push_back(nucleus_i);
         }
         return nuclei_type(values.begin(), values.end());
+    };
+
+    auto get_charges_fxn = [](nuclei_reference self) { return self.charges(); };
+    auto set_charges_fxn = [](nuclei_reference self, charges_type charges) {
+        self.charges() = charges;
     };
 
     auto push_back = [](nuclei_reference self, value_type v) {
@@ -57,6 +63,7 @@ void export_nuclei(python_module_reference m) {
     python_class_type<nuclei_type>(m, "Nuclei")
       .def(pybind11::init<>())
       .def(pybind11::init(list_ctor))
+      .def_property("charges", get_charges_fxn, set_charges_fxn)
       .def("empty", [](nuclei_reference self) { return self.empty(); })
       .def("push_back", push_back)
       .def("at", [](nuclei_reference self, size_type i) { return self[i]; })

--- a/src/python/chemical_system/point_charge/export_charges.cpp
+++ b/src/python/chemical_system/point_charge/export_charges.cpp
@@ -31,6 +31,12 @@ void export_charges_(const char* name, python_module_reference m) {
     using value_type        = typename charges_type::value_type;
     using size_type         = typename charges_type::size_type;
 
+    auto str_fxn = [](const charges_type& charges) {
+        std::ostringstream stream;
+        stream << charges;
+        return stream.str();
+    };
+
     python_class_type<charges_type>(m, name)
       .def(pybind11::init<>())
       .def("empty", [](charges_reference self) { return self.empty(); })
@@ -40,6 +46,7 @@ void export_charges_(const char* name, python_module_reference m) {
            })
       .def("at", [](charges_reference self, size_type i) { return self[i]; })
       .def("size", [](charges_reference self) { return self.size(); })
+      .def("__str__", str_fxn)
       .def(pybind11::self == pybind11::self)
       .def(pybind11::self != pybind11::self);
 }

--- a/src/python/chemical_system/point_charge/export_charges.cpp
+++ b/src/python/chemical_system/point_charge/export_charges.cpp
@@ -17,6 +17,7 @@
 #include "export_point_charge.hpp"
 #include <chemist/chemical_system/point_charge/charges.hpp>
 #include <pybind11/operators.h>
+#include <sstream>
 
 namespace chemist {
 namespace detail_ {

--- a/src/python/chemical_system/point_charge/export_charges_view.cpp
+++ b/src/python/chemical_system/point_charge/export_charges_view.cpp
@@ -28,13 +28,21 @@ void export_charges_view_(const char* name, python_module_reference m) {
     using reference    = view_type&;
     using size_type    = typename view_type::size_type;
 
+    auto str_fxn = [](const view_type& charges) {
+        std::ostringstream stream;
+        stream << charges;
+        return stream.str();
+    };
+
     python_class_type<view_type>(m, name)
       .def(pybind11::init<>())
       .def(pybind11::init<charges_type&>())
       .def("empty", [](reference self) { return self.empty(); })
       .def("at", [](reference self, size_type i) { return self[i]; })
       .def("size", [](reference self) { return self.size(); })
+      .def("__str__", str_fxn)
       .def(pybind11::self == pybind11::self)
+      .def(pybind11::self == charges_type())
       .def(pybind11::self != pybind11::self);
 }
 

--- a/src/python/chemical_system/point_charge/export_charges_view.cpp
+++ b/src/python/chemical_system/point_charge/export_charges_view.cpp
@@ -17,6 +17,7 @@
 #include "export_point_charge.hpp"
 #include <chemist/chemical_system/point_charge/charges_view/charges_view.hpp>
 #include <pybind11/operators.h>
+#include <sstream>
 
 namespace chemist {
 namespace detail_ {

--- a/tests/cxx/unit_tests/chemical_system/point_charge/charges.cpp
+++ b/tests/cxx/unit_tests/chemical_system/point_charge/charges.cpp
@@ -153,6 +153,26 @@ TEMPLATE_TEST_CASE("Charges", "", float, double) {
         REQUIRE(charges.size() == 3);
     }
 
+    SECTION("operator<<") {
+        std::stringstream ss;
+        ss << charges;
+
+        std::string corr("charge : 0,\n");
+        corr.append("x : 1,\n");
+        corr.append("y : 2,\n");
+        corr.append("z : 3\n");
+        corr.append("charge : 4,\n");
+        corr.append("x : 5,\n");
+        corr.append("y : 6,\n");
+        corr.append("z : 7\n");
+        corr.append("charge : 4,\n");
+        corr.append("x : 5,\n");
+        corr.append("y : 6,\n");
+        corr.append("z : 7\n");
+
+        REQUIRE(ss.str() == corr);
+    }
+
     SECTION("serialization") {
         std::stringstream ss;
         {

--- a/tests/cxx/unit_tests/chemical_system/point_charge/charges_view/charges_view.cpp
+++ b/tests/cxx/unit_tests/chemical_system/point_charge/charges_view/charges_view.cpp
@@ -16,6 +16,7 @@
 
 #include <catch2/catch.hpp>
 #include <chemist/chemical_system/point_charge/charges_view/charges_view.hpp>
+#include <sstream>
 
 template<typename ChargesType>
 void test_charges_view_guts() {

--- a/tests/cxx/unit_tests/chemical_system/point_charge/charges_view/charges_view.cpp
+++ b/tests/cxx/unit_tests/chemical_system/point_charge/charges_view/charges_view.cpp
@@ -33,6 +33,9 @@ void test_charges_view_guts() {
     view_type no_charges(defaulted_qs);
     view_type charges(charges_qs);
 
+    constexpr bool is_const_v =
+      !std::is_same_v<std::decay_t<ChargesType>, ChargesType>;
+
     SECTION("Ctors") {
         SECTION("Default") { REQUIRE(defaulted.size() == 0); }
 
@@ -105,6 +108,17 @@ void test_charges_view_guts() {
             REQUIRE(charges_copy == charges_move);
             REQUIRE(pcharges_move == &charges_move);
         }
+
+        SECTION("Can assign from Charges object") {
+            if constexpr(!is_const_v) {
+                // Must have same size
+                REQUIRE_THROWS_AS(charges = defaulted_qs, std::runtime_error);
+
+                charges_type charges_qs2{q1, q0, q2}; // Transposes first two qs
+                charges = charges_qs2;
+                REQUIRE(charges == charges_qs2);
+            }
+        }
     }
 
     SECTION("at_()") {
@@ -153,6 +167,26 @@ void test_charges_view_guts() {
             REQUIRE(charges != defaulted_qs);
             REQUIRE(defaulted_qs != charges);
         }
+    }
+
+    SECTION("operator<<") {
+        std::stringstream ss;
+        ss << charges;
+
+        std::string corr("charge : 0,\n");
+        corr.append("x : 0,\n");
+        corr.append("y : 0,\n");
+        corr.append("z : 0\n");
+        corr.append("charge : -1.1,\n");
+        corr.append("x : 1,\n");
+        corr.append("y : 2,\n");
+        corr.append("z : 3\n");
+        corr.append("charge : -2.2,\n");
+        corr.append("x : 4,\n");
+        corr.append("y : 5,\n");
+        corr.append("z : 6\n");
+
+        REQUIRE(ss.str() == corr);
     }
 }
 

--- a/tests/python/unit_tests/chemical_system/nucleus/test_nuclei.py
+++ b/tests/python/unit_tests/chemical_system/nucleus/test_nuclei.py
@@ -22,6 +22,21 @@ class TestNuclei(unittest.TestCase):
         self.assertTrue(self.defaulted.empty())
         self.assertFalse(self.has_value.empty())
 
+    def test_charges(self):
+        self.assertEqual(self.defaulted.charges, chemist.ChargesD())
+
+        corr = chemist.ChargesD()
+        corr.push_back(chemist.PointChargeD())
+        corr.push_back(chemist.PointChargeD(5.0, 2.0, 3.0, 4.0))
+        self.assertEqual(self.has_value.charges, corr)
+
+        # Can write to it
+        corr2 = chemist.ChargesD()
+        corr2.push_back(chemist.PointChargeD(6.0, 7.0, 8.0, 9.0))
+        corr2.push_back(chemist.PointChargeD(5.0, 2.0, 3.0, 4.0))
+        self.has_value.charges = corr2
+        self.assertEqual(self.has_value.charges, corr2)
+
     def test_push_back(self):
         # Sanity check
         self.assertEqual(self.defaulted.size(), 0)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Right now in Python we can't call gradient modules correctly because `Nuclei` didn't expose the Charges piece. This PR fixes that.

**TODOs**
None if CI passes.
