### PR TITLE
Exposes `MoleculeView::nuclei()` to Python

### DIFF
--- a/src/python/chemical_system/molecule/export_molecule.cpp
+++ b/src/python/chemical_system/molecule/export_molecule.cpp
@@ -80,8 +80,7 @@ void export_molecule_(python_module_reference m) {
       .def(pybind11::init(value_ctor))
       .def("empty", [](molecule_reference self) { return self.empty(); })
       .def("push_back", push_back)
-      .def_property("nuclei", get_nuclei_fxn, set_nuclei_fxn,
-                    pybind11::return_value_policy::copy, ka)
+      .def_property("nuclei", get_nuclei_fxn, set_nuclei_fxn)
       .def("at", at_fxn, ka)
       .def("size", [](molecule_reference self) { return self.size(); })
       .def("charge", &Molecule::charge)

--- a/src/python/chemical_system/molecule/export_molecule.cpp
+++ b/src/python/chemical_system/molecule/export_molecule.cpp
@@ -80,7 +80,8 @@ void export_molecule_(python_module_reference m) {
       .def(pybind11::init(value_ctor))
       .def("empty", [](molecule_reference self) { return self.empty(); })
       .def("push_back", push_back)
-      .def_property("nuclei", get_nuclei_fxn, set_nuclei_fxn)
+      .def_property("nuclei", get_nuclei_fxn, set_nuclei_fxn,
+                    pybind11::return_value_policy::copy, ka)
       .def("at", at_fxn, ka)
       .def("size", [](molecule_reference self) { return self.size(); })
       .def("charge", &Molecule::charge)

--- a/src/python/chemical_system/molecule/export_molecule_view.cpp
+++ b/src/python/chemical_system/molecule/export_molecule_view.cpp
@@ -29,11 +29,18 @@ void export_molecule_view(python_module_reference m) {
     using reference     = view_type&;
     using size_type     = typename molecule_type::size_type;
     using charge_type   = typename molecule_type::charge_type;
+    using nuclei_type   = typename molecule_type::nuclei_type;
+
+    auto get_nuclei_fxn = [](reference self) { return self.nuclei(); };
+    auto set_nuclei_fxn = [](reference self, nuclei_type nuclei) {
+        self.nuclei() = nuclei;
+    };
 
     python_class_type<view_type>(m, "MoleculeView")
       .def(pybind11::init<>())
       .def(pybind11::init<molecule_type&>())
       .def("empty", [](reference self) { return self.empty(); })
+      .def_property("nuclei", get_nuclei_fxn, set_nuclei_fxn)
       .def(
         "at", [](reference self, size_type i) { return self[i]; },
         pybind11::keep_alive<0, 1>())

--- a/tests/python/unit_tests/chemical_system/molecule/test_molecule.py
+++ b/tests/python/unit_tests/chemical_system/molecule/test_molecule.py
@@ -38,6 +38,14 @@ class TestMolecule(unittest.TestCase):
         self.assertEqual(self.defaulted.at(1), self.a1.nucleus)
         self.assertEqual(self.defaulted, self.has_value)
 
+    def test_nuclei(self):
+        corr_value = chemist.Nuclei()
+        self.assertEqual(self.defaulted.nuclei, corr_value)
+
+        corr_value.push_back(self.a0.nucleus)
+        corr_value.push_back(self.a1.nucleus)
+        self.assertEqual(self.has_value.nuclei, corr_value)
+
     def test_at(self):
         # Check values
         n0 = self.has_value.at(0)

--- a/tests/python/unit_tests/chemical_system/molecule/test_molecule_view.py
+++ b/tests/python/unit_tests/chemical_system/molecule/test_molecule_view.py
@@ -22,6 +22,14 @@ class TestMoleculeView(unittest.TestCase):
         self.assertTrue(self.defaulted.empty())
         self.assertFalse(self.has_value.empty())
 
+    def test_nuclei(self):
+        corr_value = chemist.Nuclei()
+        self.assertEqual(self.defaulted.nuclei, corr_value)
+
+        corr_value.push_back(self.a0.nucleus)
+        corr_value.push_back(self.a1.nucleus)
+        self.assertEqual(self.has_value.nuclei, corr_value)
+
     def test_at(self):
         # Check values
         n0 = self.has_value.at(0)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
The `nuclei` part of the `MoleculeView` object was not exposed to Python. This PR exposes it and adds unit tests.

**TODOs**
None. R2g.
