### PR TITLE
Exposes PointSet piece of Charges

### DIFF
--- a/include/chemist/chemical_system/detail_/tmp_utils.hpp
+++ b/include/chemist/chemical_system/detail_/tmp_utils.hpp
@@ -1,0 +1,46 @@
+/** @file tmp_utils.hpp
+ *
+ *  This file contains template meta-programming utility traits needed for
+ *  implementing many of the classes in the ChemicalSystem hierarchy (notably
+ *  the views).
+ */
+
+#pragma once
+#include <type_traits>
+
+namespace chemist::detail_ {
+
+/** @brief Enables implicit conversion from a mutable view to a read-only view.
+ *
+ *  As an example say we have a class `View<U>` where `U` may be either `T` or
+ *  `const T`. `View<T>` objects should be assignable to `View<const T>` objects
+ *  (basically the equivalent of doing `double y; const double& x = y`), but
+ *  not the other way around. Since `View<T>` and `View<const T>` are different
+ *  types, the conversion will not happen automatically and we must define an
+ *  implicit conversion. We also only want this conversion to only be callable
+ *  when the *this argument is `View<const T>` and the explict argument is of
+ *  type `View<T>`.
+ *
+ *  The enable_mutable_to_const_t variable template can be used to ensure that a
+ *  conversion is only considered under these conditions (this happens via
+ *  SFINAE). To use this variable template looks like:
+ *
+ *  ```
+ *  template<typename T, typename = enable_mutable_to_const<T>>
+ *  View(const View<T>& other) :
+ *  ```
+ *
+ *  @note When using this variable template like the code snippet shows do NOT
+ *        mark the ctor as explicit (or it won't be considered unless you
+ *        explicitly cast).
+ *
+ *  @tparam U The template type parameter of the view which will be the *this
+ *            argument of the conversion.
+ *  @tparam T the template type parameter of the view which we are trying to
+ *            convert from.
+ */
+template<typename T, typename U>
+using enable_mutable_to_const_t =
+  std::enable_if_t<std::is_const_v<U> && std::is_same_v<const T, U>>;
+
+} // namespace chemist::detail_

--- a/include/chemist/chemical_system/detail_/tmp_utils.hpp
+++ b/include/chemist/chemical_system/detail_/tmp_utils.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** @file tmp_utils.hpp
  *
  *  This file contains template meta-programming utility traits needed for

--- a/include/chemist/chemical_system/point_charge/charges_view/charges_view.hpp
+++ b/include/chemist/chemical_system/point_charge/charges_view/charges_view.hpp
@@ -205,6 +205,10 @@ public:
     /// Default no-throw dtor
     ~ChargesView() noexcept;
 
+    point_set_reference point_set();
+
+    const_point_set_reference point_set() const;
+
     /** @brief Determines if *this aliases the same Charges object as @p rhs.
      *
      *  This method will compare the Charges objects aliased by *this and

--- a/include/chemist/chemical_system/point_charge/charges_view/charges_view.hpp
+++ b/include/chemist/chemical_system/point_charge/charges_view/charges_view.hpp
@@ -81,6 +81,10 @@ public:
     /// Type acting like a mutable reference to the PointSet piece of *this
     using point_set_reference = typename point_set_traits::view_type;
 
+    /// Type acting like a read-only reference to the PointSet piece of *this
+    using const_point_set_reference =
+      typename point_set_traits::const_view_type;
+
     /// Traits of the PointCharge objects in *this
     using point_charge_traits = typename charges_traits::point_charge_traits;
 
@@ -205,9 +209,30 @@ public:
     /// Default no-throw dtor
     ~ChargesView() noexcept;
 
-    point_set_reference point_set();
+    /** @brief Returns a mutable reference to the PointSet piece of *this.
+     *
+     *  Charges objects are ultimately a set of points, each of which also
+     *  carries a charge. This method is used to access the PointSet piece of
+     *  *this.
+     *
+     *  @return A mutable reference to the piece of *this which behaves like a
+     *          PointSet object.
+     *
+     *  @throw None No throw guarantee.
+     */
+    point_set_reference point_set() noexcept;
 
-    const_point_set_reference point_set() const;
+    /** @brief Returns a read-only reference to the PointSet piece of *this.
+     *
+     *  This method behaves identical to the non-const version except that the
+     *  resulting reference is read-only.
+     *
+     *  @return A read-only reference to the piece of *this which behaves like a
+     *          PointSet object.
+     *
+     *  @throw None No throw guarantee.
+     */
+    const_point_set_reference point_set() const noexcept;
 
     /** @brief Determines if *this aliases the same Charges object as @p rhs.
      *

--- a/include/chemist/point/point_set_view/point_set_view.hpp
+++ b/include/chemist/point/point_set_view/point_set_view.hpp
@@ -307,7 +307,7 @@ public:
      *  @throw std::bad_alloc if there is a problem allocating the return.
      *                        Strong throw guarantee.
      */
-    point_set_type as_points() const;
+    point_set_type as_point_set() const;
 
 private:
     /// Allow base class to access implementations

--- a/include/chemist/point/point_set_view/point_set_view.hpp
+++ b/include/chemist/point/point_set_view/point_set_view.hpp
@@ -296,6 +296,19 @@ public:
      */
     bool operator!=(const PointSetView& rhs) const noexcept;
 
+    /** @brief Converts *this into a PointSet object.
+     *
+     *  PointSetViews alias their state, whereas PointSet objects own their
+     *  state. This method is used to convert *this from aliasing its state
+     *  to owning it (this happens by deep copying the internal state).
+     *
+     *  @return A new PointSet object containing a copy of the state in *this.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the return.
+     *                        Strong throw guarantee.
+     */
+    point_set_type as_points() const;
+
 private:
     /// Allow base class to access implementations
     friend base_type;

--- a/include/chemist/point/point_set_view/point_set_view.hpp
+++ b/include/chemist/point/point_set_view/point_set_view.hpp
@@ -15,6 +15,7 @@
  */
 
 #pragma once
+#include <chemist/chemical_system/detail_/tmp_utils.hpp>
 #include <chemist/point/point_set.hpp>
 #include <chemist/traits/point_traits.hpp>
 #include <memory>
@@ -45,6 +46,10 @@ private:
     using base_type =
       utilities::IndexableContainerBase<PointSetView<PointSetType>>;
 
+    template<typename T>
+    using enable_mutable_to_const_t =
+      detail_::enable_mutable_to_const_t<T, PointSetType>;
+
 public:
     /// Traits associated with PointSetType
     using traits_type = ChemistClassTraits<PointSetType>;
@@ -72,6 +77,9 @@ public:
 
     /// Type of a pointer to a PIMPL
     using pimpl_pointer = std::unique_ptr<pimpl_type>;
+
+    /// Type of a pointer to a mutable coordinate in a Point
+    using coord_pointer = typename point_traits_type::coord_pointer;
 
     /// Type used for indexing and offsets
     using typename base_type::size_type;
@@ -103,6 +111,53 @@ public:
      *                        state. Strong throw guarantee.
      */
     explicit PointSetView(point_set_reference ps);
+
+    /** @brief Creates a PointSetView from three contiguous buffers.
+     *
+     *  This ctor is used when you have three separate contiguous buffers, one
+     *  for each coordinate, and you want to treat those buffers as if they
+     *  were a PointSetView object.
+     *
+     *  @param[in] n_points The length of each buffer.
+     *  @param[in] px A pointer to the x-coordinate of the first point. Should
+     *                be a null pointer if @p n_points is 0.
+     *  @param[in] py A pointer to the y-coordinate of the first point. Should
+     *                be a null pointer if @p n_points is 0.
+     *  @param[in] pz A pointer to the z-coordinate of the first point. Should
+     *                be a null pointer if @p n_points is 0.
+     *
+     *  @throw None No throw guarantee.
+     */
+    PointSetView(size_type n_points, coord_pointer px, coord_pointer py,
+                 coord_pointer pz);
+
+    /** @brief Implicitly allows mutable PointSetView objects to be converted
+     *         to read-only PointSetView objects.
+     *
+     *  @tparam PointSetType2 The type @p other is serving as a view of. This
+     *                        ctor only participates in overload resolution when
+     *                        @p PointSetType2 is a non-const type and the type
+     *                        *this is a view of is read-only.
+     *  @tparam <anonymous> Used to disable/enable this ctor via SFINAE
+     *
+     *  This ctor allows views of mutable PointSet objects to be implicitly
+     *  converted to views of read-only PointSets. This is roughly the same
+     *  implicit conversion that occurs when a reference to a mutable object
+     *  is used by something that wants a reference to a read-only object.
+     *
+     *  @param[in] other The mutable view we want to implicitly convert to a
+     *                   read-only view.
+     *
+     *  @throw std::bad_alloc Throws if there is a problem allocating the PIMPL.
+     *                        Strong throw guarantee.
+     */
+    template<typename PointSetType2,
+             typename = enable_mutable_to_const_t<PointSetType2>>
+    PointSetView(const PointSetView<PointSetType2>& other) :
+      // N.b. this implementation will NOT work if we add more PIMPL types
+      PointSetView(other.size(), other.size() ? &other.at(0).coord(0) : nullptr,
+                   other.size() ? &other.at(0).coord(1) : nullptr,
+                   other.size() ? &other.at(0).coord(2) : nullptr) {}
 
     /** @brief Base ctor for stateful ctors.
      *

--- a/src/chemist/chemical_system/point_charge/charges_view/charges_view.cpp
+++ b/src/chemist/chemical_system/point_charge/charges_view/charges_view.cpp
@@ -54,6 +54,18 @@ TPARAMS
 CHARGES_VIEW::~ChargesView() noexcept = default;
 
 TPARAMS
+typename CHARGES_VIEW::point_set_reference CHARGES_VIEW::point_set() {
+    return has_pimpl_() ? m_pimpl_->point_set() : point_set_reference{};
+}
+
+TPARAMS
+typename CHARGES_VIEW::const_point_set_reference CHARGES_VIEW::point_set()
+  const {
+    return has_pimpl_() ? std::as_const(*m_pimpl_).point_set() :
+                          const_point_set_reference{};
+}
+
+TPARAMS
 bool CHARGES_VIEW::operator==(const ChargesView& rhs) const noexcept {
     if(this->empty() != rhs.empty()) return false;
     if(this->empty()) return true;

--- a/src/chemist/chemical_system/point_charge/charges_view/charges_view.cpp
+++ b/src/chemist/chemical_system/point_charge/charges_view/charges_view.cpp
@@ -54,13 +54,13 @@ TPARAMS
 CHARGES_VIEW::~ChargesView() noexcept = default;
 
 TPARAMS
-typename CHARGES_VIEW::point_set_reference CHARGES_VIEW::point_set() {
+typename CHARGES_VIEW::point_set_reference CHARGES_VIEW::point_set() noexcept {
     return has_pimpl_() ? m_pimpl_->point_set() : point_set_reference{};
 }
 
 TPARAMS
 typename CHARGES_VIEW::const_point_set_reference CHARGES_VIEW::point_set()
-  const {
+  const noexcept {
     return has_pimpl_() ? std::as_const(*m_pimpl_).point_set() :
                           const_point_set_reference{};
 }

--- a/src/chemist/chemical_system/point_charge/charges_view/detail_/charges_contiguous.hpp
+++ b/src/chemist/chemical_system/point_charge/charges_view/detail_/charges_contiguous.hpp
@@ -132,10 +132,12 @@ protected:
     }
 
     /// Returns the PointSetView used to implement *this
-    point_set_reference point_set_() override { return m_points_; }
+    point_set_reference point_set_() noexcept override { return m_points_; }
 
     /// Returns a read-only view of the PointSetView used to implement *this
-    const_point_set_reference point_set() const override { return m_points_; }
+    const_point_set_reference point_set_() const noexcept override {
+        return m_points_;
+    }
 
     /// Defers to the PointSet piece of *this for the number of point charges
     size_type size_() const noexcept override { return m_points_.size(); }

--- a/src/chemist/chemical_system/point_charge/charges_view/detail_/charges_contiguous.hpp
+++ b/src/chemist/chemical_system/point_charge/charges_view/detail_/charges_contiguous.hpp
@@ -58,6 +58,10 @@ public:
     /// Type of a mutable reference to the PointSet piece of *this
     using point_set_reference = typename point_set_traits::view_type;
 
+    /// Type of a read-only reference to the PointSet piece of *this
+    using const_point_set_reference =
+      typename point_set_traits::const_view_type;
+
     /// Type of a mutable pointer to a charge
     using charge_pointer = typename point_charge_traits::charge_pointer;
 
@@ -126,6 +130,12 @@ protected:
     const_reference at_(size_type i) const noexcept override {
         return const_reference(m_pcharges_[i], m_points_[i]);
     }
+
+    /// Returns the PointSetView used to implement *this
+    point_set_reference point_set_() override { return m_points_; }
+
+    /// Returns a read-only view of the PointSetView used to implement *this
+    const_point_set_reference point_set() const override { return m_points_; }
 
     /// Defers to the PointSet piece of *this for the number of point charges
     size_type size_() const noexcept override { return m_points_.size(); }

--- a/src/chemist/chemical_system/point_charge/charges_view/detail_/charges_view_pimpl.hpp
+++ b/src/chemist/chemical_system/point_charge/charges_view/detail_/charges_view_pimpl.hpp
@@ -82,6 +82,28 @@ public:
     // -- Accessors
     // -------------------------------------------------------------------------
 
+    /** @brief Returns the PointSet piece of *this
+     *
+     * Every Charges PIMPL contains the data to create a PointSet object. This
+     * method is used to access that data as if it were in a PointSet object.
+     *
+     * @return A view of the piece of *this which acts like a PointSet.
+     *
+     * @throw None No throw guarantee.
+     */
+    point_set_reference point_set() { return point_set_(); }
+
+    /** @brief Returns the PointSet piece of *this
+     *
+     * This is the same as the non-const version except that the resulting
+     * view is read-only.
+     *
+     * @return A view of the piece of *this which acts like a PointSet.
+     *
+     * @throw None No throw guarantee.
+     */
+    const_point_set_reference point_set() const { return point_set_(); }
+
     /// Returns mutable reference to the i-th point charge, implemented by at_
     reference operator[](size_type i) noexcept { return at_(i); }
 
@@ -107,6 +129,12 @@ protected:
 
     /// Derived class should override to implement clone
     virtual pimpl_pointer clone_() const = 0;
+
+    /// Derived class should override to implement point_set()
+    virtual point_set_reference point_set_() = 0;
+
+    /// Derived class should override to implement point_set() const
+    virtual const_point_set_reference point_set_() const = 0;
 
     /// Derived class should overrideto implement mutable at, operator[]
     virtual reference at_(size_type i) noexcept = 0;

--- a/src/chemist/chemical_system/point_charge/charges_view/detail_/charges_view_pimpl.hpp
+++ b/src/chemist/chemical_system/point_charge/charges_view/detail_/charges_view_pimpl.hpp
@@ -50,6 +50,13 @@ public:
     /// Traits class defining the types for the PointCharge class
     using point_charge_traits = typename parent_type::point_charge_traits;
 
+    /// Type parent uses to return the mutable PointSet piece
+    using point_set_reference = typename parent_type::point_set_reference;
+
+    /// Type parent uses to return the read-only PointSet piece
+    using const_point_set_reference =
+      typename parent_type::const_point_set_reference;
+
     /// Type used for indexing and offsets
     using size_type = typename parent_type::size_type;
 
@@ -91,7 +98,7 @@ public:
      *
      * @throw None No throw guarantee.
      */
-    point_set_reference point_set() { return point_set_(); }
+    point_set_reference point_set() noexcept { return point_set_(); }
 
     /** @brief Returns the PointSet piece of *this
      *
@@ -102,7 +109,9 @@ public:
      *
      * @throw None No throw guarantee.
      */
-    const_point_set_reference point_set() const { return point_set_(); }
+    const_point_set_reference point_set() const noexcept {
+        return point_set_();
+    }
 
     /// Returns mutable reference to the i-th point charge, implemented by at_
     reference operator[](size_type i) noexcept { return at_(i); }
@@ -131,10 +140,10 @@ protected:
     virtual pimpl_pointer clone_() const = 0;
 
     /// Derived class should override to implement point_set()
-    virtual point_set_reference point_set_() = 0;
+    virtual point_set_reference point_set_() noexcept = 0;
 
     /// Derived class should override to implement point_set() const
-    virtual const_point_set_reference point_set_() const = 0;
+    virtual const_point_set_reference point_set_() const noexcept = 0;
 
     /// Derived class should overrideto implement mutable at, operator[]
     virtual reference at_(size_type i) noexcept = 0;

--- a/src/chemist/point/point_set_view/point_set_view.cpp
+++ b/src/chemist/point/point_set_view/point_set_view.cpp
@@ -88,7 +88,7 @@ bool POINT_SET_VIEW::operator!=(const PointSetView& rhs) const noexcept {
 }
 
 TPARAMS
-typename POINT_SET_VIEW::point_set_type POINT_SET_VIEW::as_points() const {
+typename POINT_SET_VIEW::point_set_type POINT_SET_VIEW::as_point_set() const {
     point_set_type rv;
     for(const auto& x : *this) rv.push_back(x.as_point());
     return rv;

--- a/src/chemist/point/point_set_view/point_set_view.cpp
+++ b/src/chemist/point/point_set_view/point_set_view.cpp
@@ -87,6 +87,13 @@ bool POINT_SET_VIEW::operator!=(const PointSetView& rhs) const noexcept {
     return !(*this == rhs);
 }
 
+TPARAMS
+typename POINT_SET_VIEW::point_set_type POINT_SET_VIEW::as_points() const {
+    point_set_type rv;
+    for(const auto& x : *this) rv.push_back(x.as_point());
+    return rv;
+}
+
 // -----------------------------------------------------------------------------
 // -- Private member functions
 // -----------------------------------------------------------------------------

--- a/src/chemist/point/point_set_view/point_set_view.cpp
+++ b/src/chemist/point/point_set_view/point_set_view.cpp
@@ -31,8 +31,13 @@ POINT_SET_VIEW::PointSetView() noexcept = default;
 
 TPARAMS
 POINT_SET_VIEW::PointSetView(point_set_reference ps) :
+  PointSetView(ps.size(), ps.x_data(), ps.y_data(), ps.z_data()) {}
+
+TPARAMS
+POINT_SET_VIEW::PointSetView(size_type n_points, coord_pointer px,
+                             coord_pointer py, coord_pointer pz) :
   m_pimpl_(std::make_unique<detail_::PointSetContiguous<PointSetType>>(
-    ps.size(), ps.x_data(), ps.y_data(), ps.z_data())) {}
+    n_points, px, py, pz)) {}
 
 TPARAMS
 POINT_SET_VIEW::PointSetView(pimpl_pointer pimpl) noexcept :

--- a/src/python/chemical_system/point_charge/export_charge_view.cpp
+++ b/src/python/chemical_system/point_charge/export_charge_view.cpp
@@ -30,11 +30,13 @@ void export_charge_view_(const char* name, python_module_reference m) {
       typename charge_view_type::point_charge_reference;
     using point_view_type = typename charge_view_type::point_view_type;
 
+
     python_class_type<charge_view_type, point_view_type>(m, name)
       .def(pybind11::init<point_charge_reference>())
       .def_property(
         "charge", [](charge_view_type& self) { return self.charge(); },
         [](charge_view_type& self, charge_type q) { self.charge() = q; })
+
       .def(pybind11::self == pybind11::self)
       .def(pybind11::self == point_charge_type())
       .def(point_charge_type() == pybind11::self)

--- a/src/python/chemical_system/point_charge/export_charge_view.cpp
+++ b/src/python/chemical_system/point_charge/export_charge_view.cpp
@@ -30,7 +30,6 @@ void export_charge_view_(const char* name, python_module_reference m) {
       typename charge_view_type::point_charge_reference;
     using point_view_type = typename charge_view_type::point_view_type;
 
-
     python_class_type<charge_view_type, point_view_type>(m, name)
       .def(pybind11::init<point_charge_reference>())
       .def_property(

--- a/src/python/chemical_system/point_charge/export_charges_view.cpp
+++ b/src/python/chemical_system/point_charge/export_charges_view.cpp
@@ -24,10 +24,11 @@ namespace detail_ {
 
 template<typename T>
 void export_charges_view_(const char* name, python_module_reference m) {
-    using view_type    = ChargesView<Charges<T>>;
-    using charges_type = typename view_type::charges_type;
-    using reference    = view_type&;
-    using size_type    = typename view_type::size_type;
+    using view_type           = ChargesView<Charges<T>>;
+    using charges_type        = typename view_type::charges_type;
+    using reference           = view_type&;
+    using size_type           = typename view_type::size_type;
+    using point_set_reference = typename view_type::point_set_reference;
 
     auto str_fxn = [](const view_type& charges) {
         std::ostringstream stream;
@@ -38,6 +39,11 @@ void export_charges_view_(const char* name, python_module_reference m) {
     python_class_type<view_type>(m, name)
       .def(pybind11::init<>())
       .def(pybind11::init<charges_type&>())
+      .def_property(
+        "point_set", [](reference self) { return self.point_set(); },
+        [](reference self, point_set_reference points) {
+            self.point_set() = points;
+        })
       .def("empty", [](reference self) { return self.empty(); })
       .def("at", [](reference self, size_type i) { return self[i]; })
       .def("size", [](reference self) { return self.size(); })

--- a/src/python/point/export_point_set_view.cpp
+++ b/src/python/point/export_point_set_view.cpp
@@ -32,6 +32,7 @@ void export_point_set_view_(const char* name, python_module_reference m) {
       .def("empty", [](reference self) { return self.empty(); })
       .def("at", [](reference self, size_type i) { return self[i]; })
       .def("size", [](reference self) { return self.size(); })
+      .def("as_points", [](reference self) { return self.as_points(); })
       .def(pybind11::self == pybind11::self)
       .def(pybind11::self != pybind11::self);
 }

--- a/src/python/point/export_point_set_view.cpp
+++ b/src/python/point/export_point_set_view.cpp
@@ -32,7 +32,7 @@ void export_point_set_view_(const char* name, python_module_reference m) {
       .def("empty", [](reference self) { return self.empty(); })
       .def("at", [](reference self, size_type i) { return self[i]; })
       .def("size", [](reference self) { return self.size(); })
-      .def("as_points", [](reference self) { return self.as_points(); })
+      .def("as_point_set", [](reference self) { return self.as_point_set(); })
       .def(pybind11::self == pybind11::self)
       .def(pybind11::self != pybind11::self);
 }

--- a/tests/cxx/unit_tests/chemical_system/point_charge/charges_view/charges_view.cpp
+++ b/tests/cxx/unit_tests/chemical_system/point_charge/charges_view/charges_view.cpp
@@ -23,7 +23,9 @@ void test_charges_view_guts() {
     using charges_type        = ChargesType;
     using view_type           = chemist::ChargesView<charges_type>;
     using point_charge_type   = typename view_type::value_type;
+    using point_set_type      = typename view_type::point_set_type;
     using point_set_reference = typename view_type::point_set_reference;
+    using point_type          = typename point_set_reference::value_type;
     using const_point_set_reference =
       typename view_type::const_point_set_reference;
 
@@ -140,7 +142,12 @@ void test_charges_view_guts() {
     SECTION("point_set()") {
         REQUIRE(defaulted.point_set() == point_set_reference{});
         REQUIRE(no_charges.point_set() == point_set_reference{});
-        REQUIRE(charges.point_set() == point_set_reference{});
+
+        point_type p0(0.0, 0.0, 0.0);
+        point_type p1(1.0, 2.0, 3.0);
+        point_type p2(4.0, 5.0, 6.0);
+        point_set_type corr{p0, p1, p2};
+        REQUIRE(charges.point_set() == point_set_reference{corr});
     }
 
     SECTION("point_set() const") {
@@ -148,8 +155,13 @@ void test_charges_view_guts() {
                 const_point_set_reference{});
         REQUIRE(std::as_const(no_charges).point_set() ==
                 const_point_set_reference{});
+
+        point_type p0(0.0, 0.0, 0.0);
+        point_type p1(1.0, 2.0, 3.0);
+        point_type p2(4.0, 5.0, 6.0);
+        point_set_type corr{p0, p1, p2};
         REQUIRE(std::as_const(charges).point_set() ==
-                const_point_set_reference{});
+                const_point_set_reference{corr});
     }
 
     SECTION("size_()") {

--- a/tests/cxx/unit_tests/chemical_system/point_charge/charges_view/charges_view.cpp
+++ b/tests/cxx/unit_tests/chemical_system/point_charge/charges_view/charges_view.cpp
@@ -20,9 +20,12 @@
 
 template<typename ChargesType>
 void test_charges_view_guts() {
-    using charges_type      = ChargesType;
-    using view_type         = chemist::ChargesView<charges_type>;
-    using point_charge_type = typename view_type::value_type;
+    using charges_type        = ChargesType;
+    using view_type           = chemist::ChargesView<charges_type>;
+    using point_charge_type   = typename view_type::value_type;
+    using point_set_reference = typename view_type::point_set_reference;
+    using const_point_set_reference =
+      typename view_type::const_point_set_reference;
 
     // Make some Point objects and put them in a PointSet
     point_charge_type q0{0.0, 0.0, 0.0, 0.0}, q1{-1.1, 1.0, 2.0, 3.0},
@@ -132,6 +135,21 @@ void test_charges_view_guts() {
         REQUIRE(std::as_const(charges)[0] == q0);
         REQUIRE(std::as_const(charges)[1] == q1);
         REQUIRE(std::as_const(charges)[2] == q2);
+    }
+
+    SECTION("point_set()") {
+        REQUIRE(defaulted.point_set() == point_set_reference{});
+        REQUIRE(no_charges.point_set() == point_set_reference{});
+        REQUIRE(charges.point_set() == point_set_reference{});
+    }
+
+    SECTION("point_set() const") {
+        REQUIRE(std::as_const(defaulted).point_set() ==
+                const_point_set_reference{});
+        REQUIRE(std::as_const(no_charges).point_set() ==
+                const_point_set_reference{});
+        REQUIRE(std::as_const(charges).point_set() ==
+                const_point_set_reference{});
     }
 
     SECTION("size_()") {

--- a/tests/cxx/unit_tests/chemical_system/point_charge/charges_view/detail_/charges_contiguous.cpp
+++ b/tests/cxx/unit_tests/chemical_system/point_charge/charges_view/detail_/charges_contiguous.cpp
@@ -23,6 +23,8 @@ void test_case_guts() {
     using pimpl_type   = chemist::detail_::ChargesContiguous<charges_type>;
     using charge_type  = typename pimpl_type::point_charge_traits::charge_type;
     using point_set_reference = typename pimpl_type::point_set_reference;
+    using const_point_set_reference =
+      typename pimpl_type::const_point_set_reference;
     using point_set_type = typename pimpl_type::point_set_traits::value_type;
     using point_type     = typename point_set_type::value_type;
     using reference      = typename pimpl_type::reference;
@@ -79,6 +81,21 @@ void test_case_guts() {
     }
 
     // n.b. base class does bounds checks our checks should be in bounds
+
+    SECTION("point_set()") {
+        REQUIRE(defaulted.point_set() == point_set_reference{});
+        REQUIRE(no_charges.point_set() == point_set_reference{});
+        REQUIRE(charges.point_set() == point_set_reference{points});
+    }
+
+    SECTION("point_set() const") {
+        REQUIRE(std::as_const(defaulted).point_set() ==
+                const_point_set_reference{});
+        REQUIRE(std::as_const(no_charges).point_set() ==
+                const_point_set_reference{});
+        REQUIRE(std::as_const(charges).point_set() ==
+                const_point_set_reference{points});
+    }
 
     SECTION("at_()") {
         REQUIRE(charges[0] == q0);

--- a/tests/cxx/unit_tests/point/point_set_view/point_set_view.cpp
+++ b/tests/cxx/unit_tests/point/point_set_view/point_set_view.cpp
@@ -280,6 +280,13 @@ void test_point_set_view_guts() {
         REQUIRE(defaulted != one_point);
         REQUIRE_FALSE(defaulted != no_points);
     }
+
+    SECTION("as_points") {
+        REQUIRE(defaulted.as_points() == defaulted_ps);
+        REQUIRE(one_point.as_points() == one_point_ps);
+        REQUIRE(two_points.as_points() == two_points_ps);
+        REQUIRE(three_points.as_points() == three_points_ps);
+    }
 }
 
 TEMPLATE_TEST_CASE("PointSetView<T>", "", float, double) {

--- a/tests/cxx/unit_tests/point/point_set_view/point_set_view.cpp
+++ b/tests/cxx/unit_tests/point/point_set_view/point_set_view.cpp
@@ -72,6 +72,36 @@ void test_point_set_view_guts() {
             REQUIRE(three_points[1] == p1);
             REQUIRE(three_points[2] == p2);
         }
+        SECTION("pointers") {
+            view_type empty(0, nullptr, nullptr, nullptr);
+            REQUIRE(empty.size() == 0);
+
+            view_type v1(1, one_point_ps.x_data(), one_point_ps.y_data(),
+                         one_point_ps.z_data());
+            REQUIRE(v1.size() == 1);
+            REQUIRE(v1[0] == one_point_ps[0]);
+        }
+        SECTION("mutable to read-only") {
+            if constexpr(!std::is_const_v<point_set_type>) {
+                using const_type = chemist::PointSetView<const point_set_type>;
+
+                const_type const_defaulted(defaulted);
+                REQUIRE(const_defaulted.size() == 0);
+
+                const_type const_no_points(no_points);
+                REQUIRE(const_no_points.size() == 0);
+
+                const_type const_one_point(one_point);
+                REQUIRE(const_one_point.size() == 1);
+                REQUIRE(const_one_point[0] == one_point[0]);
+
+                const_type const_two_points(two_points);
+                REQUIRE(const_two_points.size() == 2);
+                REQUIRE(const_two_points[0] == two_points[0]);
+                REQUIRE(const_two_points[1] == two_points[1]);
+            }
+        }
+
         SECTION("copy") {
             // N.b. operator== is checked by setting values directly and the
             //      the "value" section has confirmed it works

--- a/tests/cxx/unit_tests/point/point_set_view/point_set_view.cpp
+++ b/tests/cxx/unit_tests/point/point_set_view/point_set_view.cpp
@@ -282,10 +282,10 @@ void test_point_set_view_guts() {
     }
 
     SECTION("as_points") {
-        REQUIRE(defaulted.as_points() == defaulted_ps);
-        REQUIRE(one_point.as_points() == one_point_ps);
-        REQUIRE(two_points.as_points() == two_points_ps);
-        REQUIRE(three_points.as_points() == three_points_ps);
+        REQUIRE(defaulted.as_point_set() == defaulted_ps);
+        REQUIRE(one_point.as_point_set() == one_point_ps);
+        REQUIRE(two_points.as_point_set() == two_points_ps);
+        REQUIRE(three_points.as_point_set() == three_points_ps);
     }
 }
 

--- a/tests/python/unit_tests/chemical_system/point_charge/test_charges_view.py
+++ b/tests/python/unit_tests/chemical_system/point_charge/test_charges_view.py
@@ -35,6 +35,13 @@ def make_test_charges_view(charges_view_type):
             q0.x = 42.0
             self.assertEqual(self.value_set.at(0).x, 42.0)
 
+        def test_point_set(self):
+            corr = self.point_set()
+            corr.push_back(self.point(0.0, 0.0, 0.0))
+            corr.push_back(self.point(2.0, 3.0, 4.0))
+            self.assertEqual(self.defaulted.point_set, self.point_set())
+            self.assertEqual(self.has_value.point_set, corr)
+
         def test_size(self):
             self.assertEqual(self.defaulted.size(), 0)
             self.assertEqual(self.has_value.size(), 2)
@@ -68,9 +75,13 @@ def make_test_charges_view(charges_view_type):
 
         def setUp(self):
             if charges_view_type == chemist.ChargesViewF:
+                self.point_set = chemist.PointSetF
+                self.point = chemist.PointF
                 self.charge_type = chemist.PointChargeF
                 self.charge_set = chemist.ChargesF
             else:
+                self.point_set = chemist.PointSetD
+                self.point = chemist.PointD
                 self.charge_type = chemist.PointChargeD
                 self.charge_set = chemist.ChargesD
 

--- a/tests/python/unit_tests/chemical_system/point_charge/test_charges_view.py
+++ b/tests/python/unit_tests/chemical_system/point_charge/test_charges_view.py
@@ -36,10 +36,14 @@ def make_test_charges_view(charges_view_type):
             self.assertEqual(self.value_set.at(0).x, 42.0)
 
         def test_point_set(self):
-            corr = self.point_set()
-            corr.push_back(self.point(0.0, 0.0, 0.0))
-            corr.push_back(self.point(2.0, 3.0, 4.0))
-            self.assertEqual(self.defaulted.point_set, self.point_set())
+            corr_ps = self.point_set()
+            corr = self.point_set_view(corr_ps)
+            self.assertEqual(self.defaulted.point_set, corr)
+
+            corr_ps = self.point_set()
+            corr_ps.push_back(self.point(0.0, 0.0, 0.0))
+            corr_ps.push_back(self.point(2.0, 3.0, 4.0))
+            corr = self.point_set_view(corr_ps)
             self.assertEqual(self.has_value.point_set, corr)
 
         def test_size(self):
@@ -76,11 +80,13 @@ def make_test_charges_view(charges_view_type):
         def setUp(self):
             if charges_view_type == chemist.ChargesViewF:
                 self.point_set = chemist.PointSetF
+                self.point_set_view = chemist.PointSetViewF
                 self.point = chemist.PointF
                 self.charge_type = chemist.PointChargeF
                 self.charge_set = chemist.ChargesF
             else:
                 self.point_set = chemist.PointSetD
+                self.point_set_view = chemist.PointSetViewD
                 self.point = chemist.PointD
                 self.charge_type = chemist.PointChargeD
                 self.charge_set = chemist.ChargesD

--- a/tests/python/unit_tests/point/test_point_set_view.py
+++ b/tests/python/unit_tests/point/test_point_set_view.py
@@ -41,8 +41,8 @@ def make_test_point_set_view(point_type, point_set_type, point_set_view_type):
             self.assertEqual(self.has_value.size(), 2)
 
         def test_as_points(self):
-            self.assertEqual(self.defaulted.as_points(), point_set_type())
-            self.assertEqual(self.has_value.as_points(), self.has_value_set)
+            self.assertEqual(self.defaulted.as_point_set(), point_set_type())
+            self.assertEqual(self.has_value.as_point_set(), self.has_value_set)
 
         def test_comparisons(self):
             # Default vs default

--- a/tests/python/unit_tests/point/test_point_set_view.py
+++ b/tests/python/unit_tests/point/test_point_set_view.py
@@ -40,6 +40,10 @@ def make_test_point_set_view(point_type, point_set_type, point_set_view_type):
             self.assertEqual(self.defaulted.size(), 0)
             self.assertEqual(self.has_value.size(), 2)
 
+        def test_as_points(self):
+            self.assertEqual(self.defaulted.as_points(), point_set_type())
+            self.assertEqual(self.has_value.as_points(), self.has_value_set)
+
         def test_comparisons(self):
             # Default vs default
             other_default = point_set_view_type()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
To take derivatives we need to specify the position at which to take the derivative. For chemical systems that's the PointSet piece. At present the PointSet piece of ChargesView is not exposed (even on the C++ side). This PR exposes PointSet, via the ChargesView class, in both C++ and Python.

**TODOs**
- [x] Test that it compiles
- [x] Test the Python bindings