### PR TITLE
Adds a DSL framework.

### DIFF
--- a/docs/source/developer/design/dsl.rst
+++ b/docs/source/developer/design/dsl.rst
@@ -1,0 +1,28 @@
+#############
+DSL Component
+#############
+
+These are notes on designing the DSL component.
+
+- We'll need DSLs for combining wavefunctions, operators, and potentially 
+  BraKets and chemical systems.
+- This component is an attempt to create a reusable DSL framework. It stops
+  shy of evaluating the expression that is created.
+- We'll have everything use CRTP to inherit from dsl::Term, that way things
+  can just take ``Term<T>`` objects and then parse the graph described by
+  the object.
+- Note that to get const-ness correct the ops need to be templated (e.g., the
+  "reference" type of an op needs to mutable if it wraps a mutable object and
+  read-only if it wraps a read-only object). This requires TMP to work out the
+  correct type.
+
+- To use the DSL promote an object in your
+
+  .. code-block:: C++
+
+     class OperatorImpl<DerivedType, ...>{
+     public:
+         template<typename DerivedType2, ...>
+         auto operator+(const OperatorImpl<DerivedType2>& rhs) const {
+             return dsl::Add<DerivedType, DerivedType2>(*this, rhs);
+         }

--- a/docs/source/developer/design/dsl.rst
+++ b/docs/source/developer/design/dsl.rst
@@ -1,3 +1,17 @@
+.. Copyright 2024 NWChemEx-Project
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+.. http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+
 #############
 DSL Component
 #############

--- a/docs/source/developer/design/index.rst
+++ b/docs/source/developer/design/index.rst
@@ -27,3 +27,4 @@ Topics in this section record the design process for the Chemist library.
    topology/index
    fragmenting/index
    quantum_mechanics/index
+   dsl

--- a/include/chemist/dsl/add.hpp
+++ b/include/chemist/dsl/add.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <chemist/dsl/binary_op.hpp>
 #include <type_traits>

--- a/include/chemist/dsl/add.hpp
+++ b/include/chemist/dsl/add.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <chemist/dsl/binary_op.hpp>
+#include <type_traits>
+
+namespace chemist::dsl {
+
+template<typename LHSType, typename RHSType>
+class Add : public BinaryOp<Add<LHSType, RHSType>, LHSType, RHSType> {
+private:
+    using my_type = Add<LHSType, RHSType>;
+    using op_type = BinaryOp<my_type, LHSType, RHSType>;
+
+public:
+    using op_type::op_type;
+};
+
+} // namespace chemist::dsl

--- a/include/chemist/dsl/binary_op.hpp
+++ b/include/chemist/dsl/binary_op.hpp
@@ -17,6 +17,7 @@
 #pragma once
 #include <chemist/dsl/term.hpp>
 #include <chemist/dsl/term_traits.hpp>
+#include <tuple>
 #include <type_traits>
 
 namespace chemist::dsl {

--- a/include/chemist/dsl/binary_op.hpp
+++ b/include/chemist/dsl/binary_op.hpp
@@ -1,0 +1,57 @@
+#pragma once
+#include <chemist/dsl/term.hpp>
+#include <type_traits>
+
+namespace chemist::dsl {
+
+template<typename DerivedType, typename LHSType, typename RHSType>
+class BinaryOp : public Term<DerivedType> {
+private:
+    template<typename T>
+    static constexpr bool is_const_v = std::is_const_v<LHSType>;
+
+    template<typename T>
+    using value_type_ = std::decay_t<T>;
+
+    template<typename T>
+    using const_reference_ = const value_type_<T>&;
+
+    template<typename T>
+    using reference_ =
+      std::conditional_t<is_const_v<T>, const_reference_<T>&, value_type_<T>>;
+
+public:
+    using lhs_type            = value_type_<LHSType>;
+    using lhs_reference       = reference_<LHSType>;
+    using const_lhs_reference = const_reference_<LHSType>;
+
+    using rhs_type            = value_type_<RHSType>;
+    using rhs_reference       = reference_<RHSType>;
+    using const_rhs_reference = const_reference_<RHSType>;
+
+    BinaryOp(lhs_reference l, rhs_reference r) : m_lhs_(l), m_rhs_(r) {}
+
+    lhs_reference lhs() { return m_lhs_; }
+    const_lhs_reference lhs() const { return m_lhs_; }
+
+    rhs_reference rhs() { return m_rhs_; }
+    const_rhs_reference rhs() const { return m_rhs_; }
+
+    template<typename DerivedType2, typename LHSType2, typename RHSType2>
+    bool operator==(
+      const BinaryOp<DerivedType2, LHSType2, RHSType2>& other) const noexcept {
+        constexpr auto l_same = std::is_same_v<lhs_type, value_type_<LHSType2>>;
+        constexpr auto r_same = std::is_same_v<rhs_type, value_type_<RHSType2>>;
+        if constexpr(l_same && r_same) {
+            return std::tie(lhs(), rhs()) == std::tie(other.lhs(), other.rhs());
+        } else {
+            return false;
+        }
+    }
+
+private:
+    lhs_reference m_lhs_;
+    rhs_reference m_rhs_;
+};
+
+} // namespace chemist::dsl

--- a/include/chemist/dsl/binary_op.hpp
+++ b/include/chemist/dsl/binary_op.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <chemist/dsl/term.hpp>
 #include <type_traits>

--- a/include/chemist/dsl/binary_op.hpp
+++ b/include/chemist/dsl/binary_op.hpp
@@ -16,58 +16,206 @@
 
 #pragma once
 #include <chemist/dsl/term.hpp>
+#include <chemist/dsl/term_traits.hpp>
 #include <type_traits>
 
 namespace chemist::dsl {
 
+/** @brief Code factorization for binary operations.
+ *
+ *  @tparam DerivedType the operation *this is implementing.
+ *  @tparam LHSType The const-qualified type of the object on the left side of
+ *                  the operation.
+ *  @tparam RHSType The const-qualified type of the object on the right side of
+ *                  the operation.
+ *
+ *  The DSL implementation of most of the binary operations are the same and is
+ *  implemented by this class.
+ */
 template<typename DerivedType, typename LHSType, typename RHSType>
 class BinaryOp : public Term<DerivedType> {
 private:
-    template<typename T>
-    static constexpr bool is_const_v = std::is_const_v<LHSType>;
+    /// Works out the types associated with LHSType
+    using lhs_traits = TermTraits<LHSType>;
 
-    template<typename T>
-    using value_type_ = std::decay_t<T>;
-
-    template<typename T>
-    using const_reference_ = const value_type_<T>&;
-
-    template<typename T>
-    using reference_ =
-      std::conditional_t<is_const_v<T>, const_reference_<T>&, value_type_<T>>;
+    /// Works out the types associated with RHSType
+    using rhs_traits = TermTraits<RHSType>;
 
 public:
-    using lhs_type            = value_type_<LHSType>;
-    using lhs_reference       = reference_<LHSType>;
-    using const_lhs_reference = const_reference_<LHSType>;
+    /// Unqualified type of the object on the left side of the operator
+    using lhs_type = typename lhs_traits::value_type;
 
-    using rhs_type            = value_type_<RHSType>;
-    using rhs_reference       = reference_<RHSType>;
-    using const_rhs_reference = const_reference_<RHSType>;
+    /// Type acting like `lhs_type&`, but respecting const-ness of @p LHSType
+    using lhs_reference = typename lhs_traits::reference;
 
+    /// Type acting like `const lhs_type&`
+    using const_lhs_reference = typename lhs_traits::const_reference;
+
+    /// Unqualified type of the object on the right side of the operator
+    using rhs_type = typename rhs_traits::value_type;
+
+    /// Type acting like `rhs_type&`, but respecting const-ness of @p RHSType
+    using rhs_reference = typename rhs_traits::reference;
+
+    /// Type acting like `const rhs_type&`.
+    using const_rhs_reference = typename rhs_traits::const_reference;
+
+    /** @brief Creates a new binary operation by aliasing @p l and @p r.
+     *
+     *  Generally speaking binary operations will want to alias the terms on
+     *  the left and right of the operator (as opposed to copying them or taking
+     *  ownership). This ctor takes references to the two objects and stores
+     *  them internally as `TermTraits<T>::holder_type` objects (where T is
+     *  @p LHSType and @p RHSType respectively for @p lhs and @p rhs). Thus
+     *  whether *this ultimately owns the objects referenced by @p lhs and
+     *  @p rhs are controlled by the respective specializations of `TermTraits`.
+     *
+     *  @param[in] l An alias to the object on the left side of the operator.
+     *  @param[in] r An alias to the object on the right side of the operator.
+     *
+     *  @throw ??? Throws if converting either @p l or @p r to the holder type
+     *             throws. Same throw guarantee.
+     */
     BinaryOp(lhs_reference l, rhs_reference r) : m_lhs_(l), m_rhs_(r) {}
 
+    // -------------------------------------------------------------------------
+    // -- Getters and setters
+    // -------------------------------------------------------------------------
+
+    /** @brief Returns a (possibly) mutable reference to the object on the left
+     *         of the operator.
+     *
+     *  *this is associated with two objects. The one that was on the left side
+     *  of the operator is termed "lhs" and can be accessed via this method.
+     *
+     *  @return A (possibly) mutable reference to the object which was on the
+     *          left of the operator. The mutable-ness of the return is
+     *          controlled by TermTraits<LHSType>.
+     *
+     *  @throw ??? Throws if converting from the held type to lhs_reference
+     *             throws. Same throw guarantee.
+     */
     lhs_reference lhs() { return m_lhs_; }
+
+    /** @brief Returns a read-only reference to the object on the left of the
+     *         operator.
+     *
+     *  This method is identical to the non-const version except that the return
+     *  is guaranteed to be read-only.
+     *
+     *  @return A read-only reference to the object on the left of the
+     *          operator.
+     *
+     *  @throw ??? Throws if converting from the held type to
+     *             const_lhs_reference throws. Same throw guarantee.
+     */
     const_lhs_reference lhs() const { return m_lhs_; }
 
+    /** @brief Returns a (possibly) mutable reference to the object on the right
+     *         of the operator.
+     *
+     *  *this is associated with two objects. The one that was on the right side
+     *  of the operator is termed "rhs" and can be accessed via this method.
+     *
+     *  @return A (possibly) mutable reference to the object which was on the
+     *          right of the operator. The mutable-ness of the return is
+     *          controlled by TermTraits<RHSType>.
+     *
+     *  @throw ??? Throws if converting from the held type to rhs_reference
+     *             throws. Same throw guarantee.
+     */
     rhs_reference rhs() { return m_rhs_; }
+
+    /** @brief Returns a read-only reference to the object on the right of the
+     *         operator.
+     *
+     *  This method is identical to the non-const version except that the return
+     *  is guaranteed to be read-only.
+     *
+     *  @return A read-only reference to the object on the right of the
+     *          operator.
+     *
+     *  @throw ??? Throws if converting from the held type to
+     *             const_rhs_reference throws. Same throw guarantee.
+     */
     const_rhs_reference rhs() const { return m_rhs_; }
 
+    // -------------------------------------------------------------------------
+    // -- Utility methods
+    // -------------------------------------------------------------------------
+
+    /** @brief Is *this the same binary op as @p other?
+     *
+     *  @tparam DerivedType2 The type @p other implements.
+     *  @tparam LHSType2 The type of lhs in @p other.
+     *  @tparam RHSType2 The type of rhs in @p other.
+     *
+     *  Two BinaryOp objects are the same if they:
+     *  - Implement the same operation, e.g., both are implementing addition,
+     *  - Both have the same value of lhs, and
+     *  - Both have the same value of rhs.
+     *
+     *  It should be noted that following C++ convention, value comparisons are
+     *  done with const references and thus the const-ness of @tparam LHSType
+     *  and @tparam RHSType vs the respective const-ness of @tparam LHSType2
+     *  and @tparam RHSType2 is not considered.
+     *
+     *  @param[in] other The object to compare to.
+     *
+     *  @return True if *this is value equal and false otherwise.
+     *
+     *  @throw None No throw guarantee.
+     */
     template<typename DerivedType2, typename LHSType2, typename RHSType2>
     bool operator==(
+      const BinaryOp<DerivedType2, LHSType2, RHSType2>& other) const noexcept;
+
+    /** @brief Is *this different than @p other?
+     *
+     *  @tparam DerivedType2 The type @p other implements.
+     *  @tparam LHSType2 The type of lhs in @p other.
+     *  @tparam RHSType2 The type of rhs in @p other.
+     *
+     *  This method defines "different" as not value equal. See the description
+     *  for operator== for the definition of value equal.
+     *
+     *  @param[in] other The object to compare to *this.
+     *
+     *  @return False if *this is value equal to @p other and true otherwise.
+     *
+     *  @throw None No throw guarantee.
+     */
+    template<typename DerivedType2, typename LHSType2, typename RHSType2>
+    bool operator!=(
       const BinaryOp<DerivedType2, LHSType2, RHSType2>& other) const noexcept {
-        constexpr auto l_same = std::is_same_v<lhs_type, value_type_<LHSType2>>;
-        constexpr auto r_same = std::is_same_v<rhs_type, value_type_<RHSType2>>;
-        if constexpr(l_same && r_same) {
-            return std::tie(lhs(), rhs()) == std::tie(other.lhs(), other.rhs());
-        } else {
-            return false;
-        }
+        return !((*this) == other);
     }
 
 private:
-    lhs_reference m_lhs_;
-    rhs_reference m_rhs_;
+    /// The object on the left side of the operator
+    typename lhs_traits::holder_type m_lhs_;
+
+    /// The object on the right side of the operator
+    typename rhs_traits::holder_type m_rhs_;
 };
+
+// -----------------------------------------------------------------------------
+// -- Out of line inline definitions
+// -----------------------------------------------------------------------------
+
+template<typename DerivedType, typename LHSType, typename RHSType>
+template<typename DerivedType2, typename LHSType2, typename RHSType2>
+bool BinaryOp<DerivedType, LHSType, RHSType>::operator==(
+  const BinaryOp<DerivedType2, LHSType2, RHSType2>& other) const noexcept {
+    using lhs2_type       = typename TermTraits<LHSType2>::value_type;
+    using rhs2_type       = typename TermTraits<RHSType2>::value_type;
+    constexpr auto l_same = std::is_same_v<lhs_type, lhs2_type>;
+    constexpr auto r_same = std::is_same_v<rhs_type, rhs2_type>;
+    if constexpr(l_same && r_same) {
+        return std::tie(lhs(), rhs()) == std::tie(other.lhs(), other.rhs());
+    } else {
+        return false;
+    }
+}
 
 } // namespace chemist::dsl

--- a/include/chemist/dsl/divide.hpp
+++ b/include/chemist/dsl/divide.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <chemist/dsl/binary_op.hpp>
+#include <type_traits>
+
+namespace chemist::dsl {
+
+/** @brief Represents the division of two terms.
+ *
+ *  @tparam LHSType The type of the object on the left of the division sign.
+ *  @tparam RHSType The type of the object on the right of the division sign.
+ *
+ *  This class is essentially a strong type over top of BinaryOp to signal
+ *  that the binary operation is division (or at the least represented
+ *  with a divide sign).
+ */
+template<typename LHSType, typename RHSType>
+class Divide : public BinaryOp<Divide<LHSType, RHSType>, LHSType, RHSType> {
+private:
+    /// Type of *this
+    using my_type = Divide<LHSType, RHSType>;
+
+    /// Type *this inherits from
+    using op_type = BinaryOp<my_type, LHSType, RHSType>;
+
+public:
+    /// Reuse the base class's ctor
+    using op_type::op_type;
+};
+
+} // namespace chemist::dsl

--- a/include/chemist/dsl/dsl.hpp
+++ b/include/chemist/dsl/dsl.hpp
@@ -1,0 +1,3 @@
+#pragma once
+#include <chemist/dsl/add.hpp>
+#include <chemist/dsl/term.hpp>

--- a/include/chemist/dsl/dsl.hpp
+++ b/include/chemist/dsl/dsl.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <chemist/dsl/add.hpp>
 #include <chemist/dsl/term.hpp>

--- a/include/chemist/dsl/dsl.hpp
+++ b/include/chemist/dsl/dsl.hpp
@@ -16,4 +16,5 @@
 
 #pragma once
 #include <chemist/dsl/add.hpp>
+#include <chemist/dsl/multiply.hpp>
 #include <chemist/dsl/term.hpp>

--- a/include/chemist/dsl/dsl.hpp
+++ b/include/chemist/dsl/dsl.hpp
@@ -16,5 +16,7 @@
 
 #pragma once
 #include <chemist/dsl/add.hpp>
+#include <chemist/dsl/divide.hpp>
 #include <chemist/dsl/multiply.hpp>
+#include <chemist/dsl/subtract.hpp>
 #include <chemist/dsl/term.hpp>

--- a/include/chemist/dsl/dsl_fwd.hpp
+++ b/include/chemist/dsl/dsl_fwd.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace chemist::dsl {
+
+template<typename LHSType, typename RHSType>
+class Add;
+
+}

--- a/include/chemist/dsl/dsl_fwd.hpp
+++ b/include/chemist/dsl/dsl_fwd.hpp
@@ -16,9 +16,28 @@
 
 #pragma once
 
+/** @file dsl_fwd.hpp
+ *
+ *  This file forward declares the classes needed to power the DSL. The
+ *  forward declarations are primarily useful for declaring interfaces and
+ *  for template meta-programming.
+ */
+
 namespace chemist::dsl {
 
 template<typename LHSType, typename RHSType>
 class Add;
 
-}
+template<typename DerivedType, typename LHSType, typename RHSType>
+class BinaryOp;
+
+template<typename LHSType, typename RHSType>
+class Multiply;
+
+template<typename DerivedType>
+class Term;
+
+template<typename T>
+class TermTraits;
+
+} // namespace chemist::dsl

--- a/include/chemist/dsl/dsl_fwd.hpp
+++ b/include/chemist/dsl/dsl_fwd.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 namespace chemist::dsl {

--- a/include/chemist/dsl/dsl_fwd.hpp
+++ b/include/chemist/dsl/dsl_fwd.hpp
@@ -32,7 +32,13 @@ template<typename DerivedType, typename LHSType, typename RHSType>
 class BinaryOp;
 
 template<typename LHSType, typename RHSType>
+class Divide;
+
+template<typename LHSType, typename RHSType>
 class Multiply;
+
+template<typename LHSType, typename RHSType>
+class Subtract;
 
 template<typename DerivedType>
 class Term;

--- a/include/chemist/dsl/multiply.hpp
+++ b/include/chemist/dsl/multiply.hpp
@@ -20,20 +20,20 @@
 
 namespace chemist::dsl {
 
-/** @brief Represents the addition of two terms.
+/** @brief Represents the multiplication of two terms.
  *
- *  @tparam LHSType The type of the object on the left of the plus sign.
- *  @tparam RHSType The type of the object on the right of the plus sign.
+ *  @tparam LHSType The type of the object on the left of the times sign.
+ *  @tparam RHSType The type of the object on the right of the times sign.
  *
  *  This class is essentially a strong type over top of BinaryOp to signal
- *  that the binary operation is addition (or at the least represented with a
- *  plus sign).
+ *  that the binary operation is multiplication (or at the least represented
+ *  with a times sign).
  */
 template<typename LHSType, typename RHSType>
-class Add : public BinaryOp<Add<LHSType, RHSType>, LHSType, RHSType> {
+class Multiply : public BinaryOp<Multiply<LHSType, RHSType>, LHSType, RHSType> {
 private:
     /// Type of *this
-    using my_type = Add<LHSType, RHSType>;
+    using my_type = Multiply<LHSType, RHSType>;
 
     /// Type *this inherits from
     using op_type = BinaryOp<my_type, LHSType, RHSType>;

--- a/include/chemist/dsl/subtract.hpp
+++ b/include/chemist/dsl/subtract.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <chemist/dsl/binary_op.hpp>
+#include <type_traits>
+
+namespace chemist::dsl {
+
+/** @brief Represents the subtraction of two terms.
+ *
+ *  @tparam LHSType The type of the object on the left of the subtraction sign.
+ *  @tparam RHSType The type of the object on the right of the subtraction sign.
+ *
+ *  This class is essentially a strong type over top of BinaryOp to signal
+ *  that the binary operation is subtraction (or at the least represented
+ *  with a minus sign).
+ */
+template<typename LHSType, typename RHSType>
+class Subtract : public BinaryOp<Subtract<LHSType, RHSType>, LHSType, RHSType> {
+private:
+    /// Type of *this
+    using my_type = Subtract<LHSType, RHSType>;
+
+    /// Type *this inherits from
+    using op_type = BinaryOp<my_type, LHSType, RHSType>;
+
+public:
+    /// Reuse the base class's ctor
+    using op_type::op_type;
+};
+
+} // namespace chemist::dsl

--- a/include/chemist/dsl/term.hpp
+++ b/include/chemist/dsl/term.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <chemist/dsl/dsl_fwd.hpp>
+
+namespace chemist::dsl {
+
+template<typename DerivedType>
+class Term {
+public:
+    template<typename RHSType>
+    auto operator+(RHSType&& rhs) {
+        auto& lhs      = static_cast<DerivedType&>(*this);
+        using no_ref_t = std::remove_reference_t<RHSType>;
+        return Add<DerivedType, no_ref_t>(lhs, std::forward<RHSType>(rhs));
+    }
+};
+
+} // namespace chemist::dsl

--- a/include/chemist/dsl/term.hpp
+++ b/include/chemist/dsl/term.hpp
@@ -19,9 +19,30 @@
 
 namespace chemist::dsl {
 
+/** @brief Base class for all elements of the DSL.
+ *
+ *  @tparam DerivedType Type of the object *this is implementing.
+ *
+ *  Users of the DSL need to implement operator+, operator-, etc. for their
+ *  leaves. The returns of those functions are DSL Term objects. Those objects
+ *  can then further be composed. The Term class implements further
+ *  composition with DSL objects.
+ */
 template<typename DerivedType>
 class Term {
 public:
+    /** @brief Adds *this to @p rhs.
+     *
+     *  @tparam RHSType The type of @p rhs.
+     *
+     *  This method will create an object representing left addition by *this
+     *  to @p rhs.
+     *
+     *  @param[in] rhs The object to *this will be added.
+     *
+     *  @throw ??? Throws if creation of the new DSL term throws. Same throw
+     *             guarantee.
+     */
     template<typename RHSType>
     auto operator+(RHSType&& rhs) {
         auto& lhs      = static_cast<DerivedType&>(*this);
@@ -29,11 +50,61 @@ public:
         return Add<DerivedType, no_ref_t>(lhs, std::forward<RHSType>(rhs));
     }
 
+    /** @brief Subtracts @p rhs from this.
+     *
+     *  @tparam RHSType The type of @p rhs.
+     *
+     *  This method will create an object representing subtracting @p rhs from
+     *  *this.
+     *
+     *  @param[in] rhs The object to be subtracted from *this.
+     *
+     *  @throw ??? Throws if creation of the new DSL term throws. Same throw
+     *             guarantee.
+     */
+    template<typename RHSType>
+    auto operator-(RHSType&& rhs) {
+        auto& lhs      = static_cast<DerivedType&>(*this);
+        using no_ref_t = std::remove_reference_t<RHSType>;
+        return Subtract<DerivedType, no_ref_t>(lhs, std::forward<RHSType>(rhs));
+    }
+
+    /** @brief Multiplies *this to @p rhs.
+     *
+     *  @tparam RHSType The type of @p rhs.
+     *
+     *  This method will create an object representing left multiplication by
+     *  *this to @p rhs.
+     *
+     *  @param[in] rhs The object *this will be multiply.
+     *
+     *  @throw ??? Throws if creation of the new DSL term throws. Same throw
+     *             guarantee.
+     */
     template<typename RHSType>
     auto operator*(RHSType&& rhs) {
         auto& lhs      = static_cast<DerivedType&>(*this);
         using no_ref_t = std::remove_reference_t<RHSType>;
         return Multiply<DerivedType, no_ref_t>(lhs, std::forward<RHSType>(rhs));
+    }
+
+    /** @brief Divides *this by @p rhs.
+     *
+     *  @tparam RHSType The type of @p rhs.
+     *
+     *  This method will create an object representing division of
+     *  *this by @p rhs.
+     *
+     *  @param[in] rhs The object to divide *this by.
+     *
+     *  @throw ??? Throws if creation of the new DSL term throws. Same throw
+     *             guarantee.
+     */
+    template<typename RHSType>
+    auto operator/(RHSType&& rhs) {
+        auto& lhs      = static_cast<DerivedType&>(*this);
+        using no_ref_t = std::remove_reference_t<RHSType>;
+        return Divide<DerivedType, no_ref_t>(lhs, std::forward<RHSType>(rhs));
     }
 };
 

--- a/include/chemist/dsl/term.hpp
+++ b/include/chemist/dsl/term.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <chemist/dsl/dsl_fwd.hpp>
 

--- a/include/chemist/dsl/term.hpp
+++ b/include/chemist/dsl/term.hpp
@@ -28,6 +28,13 @@ public:
         using no_ref_t = std::remove_reference_t<RHSType>;
         return Add<DerivedType, no_ref_t>(lhs, std::forward<RHSType>(rhs));
     }
+
+    template<typename RHSType>
+    auto operator*(RHSType&& rhs) {
+        auto& lhs      = static_cast<DerivedType&>(*this);
+        using no_ref_t = std::remove_reference_t<RHSType>;
+        return Multiply<DerivedType, no_ref_t>(lhs, std::forward<RHSType>(rhs));
+    }
 };
 
 } // namespace chemist::dsl

--- a/include/chemist/dsl/term_traits.hpp
+++ b/include/chemist/dsl/term_traits.hpp
@@ -1,0 +1,80 @@
+#pragma once
+#include <chemist/dsl/dsl_fwd.hpp>
+
+namespace chemist::dsl {
+
+/** @brief Class used to work out the DSL traits for an object of type @p T.
+ *
+ *  @tparam T The type we are working out the traits for. Can be mutable or
+ *            const-qualified
+ *
+ *  The DSL component is designed to work with a myriad of object types. In
+ *  order for this to work we need to know how to take both mutable and
+ *  read-only references to the object. This trait works out the types of those
+ *  references. Users can specialize this class to modify the behavior of the
+ *  DSL for their type
+ */
+template<typename T>
+class TermTraits {
+public:
+    /// Can @p T be expressed as `const U` where U is a non-const type?
+    static constexpr bool is_const_v = std::is_const_v<T>;
+
+    /** @brief  The type of @p T with all qualifiers removed
+     *
+     *  The TermTraits class allows the template type parameter to be qualified.
+     *  This member type strips all of the qualifiers off. This member type is
+     *  used throughout this class for:
+     *
+     *  - Deriving new types (e.g., adding an ampersand creates the reference
+     *    type).
+     *  - Determining if two TermTraits objects describe the same type
+     */
+    using value_type = std::decay_t<T>;
+
+    /** @brief The type of a read-only reference to an object of type @p T.
+     *
+     *  When a DSL term contains an object of type @p T, requests to access the
+     *  term via a read-only reference will return an object of this type. This
+     *  class defines that type as `const value_type&`.
+     */
+    using const_reference = const value_type&;
+
+    /** @brief The type of a (possibly) mutable reference to an object of
+     *         type @p T.
+     *
+     *  When a DSL term contains an object of type @p T, requests to access the
+     *  term as a mutable reference will return an object of this type. This
+     *  class defines that type as `const_reference` if @p T is a const-
+     *  qualified type and `value_type&` if @p T is not const-qualified.
+     */
+    using reference =
+      std::conditional_t<is_const_v, const_reference, value_type&>;
+
+    /** @brief Is @p T part of the DSL layer?
+     *
+     *  Terms that are part of the DSL layer are often unnamed temporaries and
+     *  their storage must be handled specially. This member variable is used
+     *  to determine if @p T either derives from dsl::Term, or if it is a
+     *  floating point type (floating point types are often specified inline as
+     *  if they were part of the DSL).
+     */
+    static constexpr bool is_dsl_term_v =
+      std::is_base_of_v<Term<value_type>, value_type> ||
+      std::is_floating_point_v<value_type>;
+
+    /** @brief The type terms will hold @p T as.
+     *
+     *  The terms of the DSL capture the inputs as the DSL is built up. When a
+     *  term needs to hold an object of type @p T it does so by storing it as
+     *  an object of type `holder_type`. For leaf objects (objects not part of
+     *  the DSL) the default is to hold them as `reference` objects. This means
+     *  that the DSL is NOT responsible for their lifetime. If @p T is an
+     *  object that is part of the DSL then @p T is captured by value (DSL
+     *  terms are expected to be light-weight and temporary).
+     */
+    using holder_type =
+      std::conditional_t<is_dsl_term_v, value_type, reference>;
+};
+
+} // namespace chemist::dsl

--- a/include/chemist/dsl/term_traits.hpp
+++ b/include/chemist/dsl/term_traits.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 #include <chemist/dsl/dsl_fwd.hpp>
 

--- a/include/chemist/quantum_mechanics/operator/detail_/operator_impl.hpp
+++ b/include/chemist/quantum_mechanics/operator/detail_/operator_impl.hpp
@@ -17,6 +17,7 @@
 #pragma once
 #include <chemist/chemical_system/electron/electron.hpp>
 #include <chemist/chemical_system/nucleus/nucleus.hpp>
+#include <chemist/dsl/dsl.hpp>
 #include <chemist/quantum_mechanics/operator/operator_base.hpp>
 #include <chemist/quantum_mechanics/operator/operator_visitor.hpp>
 #include <chemist/traits/electron_traits.hpp>
@@ -171,6 +172,11 @@ public:
      */
     bool operator!=(const OperatorImpl& rhs) const noexcept {
         return !(*this == rhs);
+    }
+
+    template<typename RHSType>
+    auto operator+(const RHSType& rhs) const {
+        return dsl::Add<const DerivedType, const RHSType>(downcast_(), rhs);
     }
 
 protected:

--- a/include/chemist/quantum_mechanics/operator/detail_/operator_impl.hpp
+++ b/include/chemist/quantum_mechanics/operator/detail_/operator_impl.hpp
@@ -190,6 +190,23 @@ public:
         return dsl::Add<const DerivedType, const RHSType>(downcast_(), rhs);
     }
 
+    /** @brief Subtracts @p rhs from *this.
+     *
+     *  @tparam RHSType The type of @p rhs. Assumed to be the type of an
+     *                  operator or the type of a DSL term involving operators.
+     *
+     *  @param[in] rhs The object to subtract from *this.
+     *
+     *  @return A DSL term describing the user's requested operation.
+     *
+     *  @throw None No throw guarantee.
+     */
+    template<typename RHSType>
+    auto operator-(const RHSType& rhs) const {
+        return dsl::Subtract<const DerivedType, const RHSType>(downcast_(),
+                                                               rhs);
+    }
+
     /** @brief Right multiplies *this by @p rhs.
      *
      *  @tparam RHSType The type of @p rhs. Assumed to be the type of an

--- a/include/chemist/quantum_mechanics/operator/detail_/operator_impl.hpp
+++ b/include/chemist/quantum_mechanics/operator/detail_/operator_impl.hpp
@@ -174,9 +174,37 @@ public:
         return !(*this == rhs);
     }
 
+    /** @brief Adds @p rhs to *this.
+     *
+     *  @tparam RHSType The type of @p rhs. Assumed to be the type of an
+     *                  operator or the type of a DSL term involving operators.
+     *
+     *  @param[in] rhs The object to add to *this.
+     *
+     *  @return A DSL term describing the user's requested operation.
+     *
+     *  @throw None No throw guarantee.
+     */
     template<typename RHSType>
     auto operator+(const RHSType& rhs) const {
         return dsl::Add<const DerivedType, const RHSType>(downcast_(), rhs);
+    }
+
+    /** @brief Right multiplies *this by @p rhs.
+     *
+     *  @tparam RHSType The type of @p rhs. Assumed to be the type of an
+     *                  operator or the type of a DSL term involving operators.
+     *
+     *  @param[in] rhs The object to multiply with *this.
+     *
+     *  @return A DSL term describing the user's requested operation.
+     *
+     *  @throw None No throw guarantee.
+     */
+    template<typename RHSType>
+    auto operator*(const RHSType& rhs) const {
+        return dsl::Multiply<const DerivedType, const RHSType>(downcast_(),
+                                                               rhs);
     }
 
 protected:
@@ -273,5 +301,23 @@ private:
     /// These are the particles the operator describes
     std::tuple<Particles...> m_particles_;
 };
+
+/** @brief Enables left multiplication by floating point values.
+ *
+ *  @tparam LHSType Type of the floating point value.
+ *  @tparam DerivedType Type OperatorImpl is implementing.
+ *  @tparam Particles Types of the particles DerivedType is templated on.
+ *  @tparam <anonymous> Used to disable this overload if @p LHSType is not a
+ *                      floating point type.
+ *
+ *  It is conventional to put scalars on the left of an operator. This function
+ *  overloads left multiplication of an operator by a scalar so that it works.
+ */
+template<typename LHSType, typename DerivedType, typename... Particles,
+         typename = std::enable_if_t<std::is_floating_point_v<LHSType>>>
+auto operator*(const LHSType& lhs,
+               const OperatorImpl<DerivedType, Particles...>& rhs) {
+    return dsl::Multiply<const LHSType, const DerivedType>(lhs, rhs);
+}
 
 } // namespace chemist::qm_operator::detail_

--- a/tests/cxx/unit_tests/dsl/add.cpp
+++ b/tests/cxx/unit_tests/dsl/add.cpp
@@ -1,0 +1,35 @@
+#include "test_dsl.hpp"
+#include <chemist/dsl/add.hpp>
+
+/* Testing Strategy.
+ *
+ * Add is basically a strong type, we just test it can be constructed with all
+ * of the possible const-variations.
+ */
+
+TEMPLATE_LIST_TEST_CASE("Add", "", test_chemist::binary_types) {
+    using lhs_type = std::tuple_element_t<0, TestType>;
+    using rhs_type = std::tuple_element_t<1, TestType>;
+
+    auto values     = test_chemist::binary_values();
+    auto [lhs, rhs] = std::get<TestType>(values);
+
+    chemist::dsl::Add<lhs_type, rhs_type> a_xx(lhs, rhs);
+    chemist::dsl::Add<const lhs_type, rhs_type> a_cx(lhs, rhs);
+    chemist::dsl::Add<lhs_type, const rhs_type> a_xc(lhs, rhs);
+    chemist::dsl::Add<const lhs_type, const rhs_type> a_cc(lhs, rhs);
+
+    SECTION("CTors") {
+        REQUIRE(a_xx.lhs() == lhs);
+        REQUIRE(a_xx.rhs() == rhs);
+
+        REQUIRE(a_cx.lhs() == lhs);
+        REQUIRE(a_cx.rhs() == rhs);
+
+        REQUIRE(a_xc.lhs() == lhs);
+        REQUIRE(a_xc.rhs() == rhs);
+
+        REQUIRE(a_cc.lhs() == lhs);
+        REQUIRE(a_cc.rhs() == rhs);
+    }
+}

--- a/tests/cxx/unit_tests/dsl/add.cpp
+++ b/tests/cxx/unit_tests/dsl/add.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "test_dsl.hpp"
 #include <chemist/dsl/add.hpp>
 

--- a/tests/cxx/unit_tests/dsl/binary_op.cpp
+++ b/tests/cxx/unit_tests/dsl/binary_op.cpp
@@ -1,0 +1,64 @@
+#include "test_dsl.hpp"
+#include <chemist/dsl/add.hpp>
+
+/* Testing Strategy.
+ *
+ * The classes which derive from BinaryOp are strong types. We thus only need
+ * to test the BinaryOp infrastructure for one derived class (we must test
+ * through the derived class because of the CRTP usage).
+ */
+
+TEMPLATE_LIST_TEST_CASE("BinaryOp", "", test_chemist::binary_types) {
+    using lhs_type = std::tuple_element_t<0, TestType>;
+    using rhs_type = std::tuple_element_t<1, TestType>;
+
+    auto values     = test_chemist::binary_values();
+    auto [lhs, rhs] = std::get<TestType>(values);
+
+    chemist::dsl::Add<lhs_type, rhs_type> a_xx(lhs, rhs);
+    chemist::dsl::Add<const lhs_type, rhs_type> a_cx(lhs, rhs);
+    chemist::dsl::Add<lhs_type, const rhs_type> a_xc(lhs, rhs);
+    chemist::dsl::Add<const lhs_type, const rhs_type> a_cc(lhs, rhs);
+
+    SECTION("CTors") {
+        REQUIRE(a_xx.lhs() == lhs);
+        REQUIRE(a_xx.rhs() == rhs);
+
+        REQUIRE(a_cx.lhs() == lhs);
+        REQUIRE(a_cx.rhs() == rhs);
+
+        REQUIRE(a_xc.lhs() == lhs);
+        REQUIRE(a_xc.rhs() == rhs);
+
+        REQUIRE(a_cc.lhs() == lhs);
+        REQUIRE(a_cc.rhs() == rhs);
+    }
+
+    SECTION("lhs()") {
+        REQUIRE(a_xx.lhs() == lhs);
+        REQUIRE(a_cx.lhs() == lhs);
+        REQUIRE(a_xc.lhs() == lhs);
+        REQUIRE(a_cc.lhs() == lhs);
+    }
+
+    SECTION("lhs() const") {
+        REQUIRE(std::as_const(a_xx).lhs() == lhs);
+        REQUIRE(std::as_const(a_cx).lhs() == lhs);
+        REQUIRE(std::as_const(a_xc).lhs() == lhs);
+        REQUIRE(std::as_const(a_cc).lhs() == lhs);
+    }
+
+    SECTION("rhs()") {
+        REQUIRE(a_xx.rhs() == rhs);
+        REQUIRE(a_cx.rhs() == rhs);
+        REQUIRE(a_xc.rhs() == rhs);
+        REQUIRE(a_cc.rhs() == rhs);
+    }
+
+    SECTION("rhs() const") {
+        REQUIRE(std::as_const(a_xx).rhs() == rhs);
+        REQUIRE(std::as_const(a_cx).rhs() == rhs);
+        REQUIRE(std::as_const(a_xc).rhs() == rhs);
+        REQUIRE(std::as_const(a_cc).rhs() == rhs);
+    }
+}

--- a/tests/cxx/unit_tests/dsl/binary_op.cpp
+++ b/tests/cxx/unit_tests/dsl/binary_op.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "test_dsl.hpp"
 #include <chemist/dsl/add.hpp>
 

--- a/tests/cxx/unit_tests/dsl/binary_op.cpp
+++ b/tests/cxx/unit_tests/dsl/binary_op.cpp
@@ -77,4 +77,45 @@ TEMPLATE_LIST_TEST_CASE("BinaryOp", "", test_chemist::binary_types) {
         REQUIRE(std::as_const(a_xc).rhs() == rhs);
         REQUIRE(std::as_const(a_cc).rhs() == rhs);
     }
+
+    SECTION("operator==") {
+        SECTION("Same values") {
+            chemist::dsl::Add<lhs_type, rhs_type> add2(lhs, rhs);
+            REQUIRE(a_xx == add2);
+        }
+
+        SECTION("Different const-ness") {
+            REQUIRE(a_xx == a_cx);
+            REQUIRE(a_xx == a_xc);
+            REQUIRE(a_xx == a_cc);
+            REQUIRE(a_cx == a_xc);
+            REQUIRE(a_cx == a_cc);
+            REQUIRE(a_xc == a_cc);
+        }
+
+        SECTION("Different values") {
+            lhs_type lhs2;
+            rhs_type rhs2;
+            chemist::dsl::Add<lhs_type, rhs_type> add_l(lhs2, rhs);
+            chemist::dsl::Add<lhs_type, rhs_type> add_r(lhs, rhs2);
+            REQUIRE_FALSE(a_xx == add_l);
+            REQUIRE_FALSE(a_xx == add_r);
+        }
+
+        SECTION("Different type") {
+            char a = 'a';
+            chemist::dsl::Add<char, rhs_type> add_l(a, rhs);
+            chemist::dsl::Add<lhs_type, char> add_r(lhs, a);
+            REQUIRE_FALSE(a_xx == add_l);
+            REQUIRE_FALSE(a_xx == add_r);
+        }
+    }
+
+    SECTION("operator!=") {
+        // Just negates operator== so spot check
+        lhs_type lhs2;
+        chemist::dsl::Add<lhs_type, rhs_type> add_r(lhs2, rhs);
+        REQUIRE_FALSE(a_xx != a_cx);
+        REQUIRE(a_xx != add_r);
+    }
 }

--- a/tests/cxx/unit_tests/dsl/divide.cpp
+++ b/tests/cxx/unit_tests/dsl/divide.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_dsl.hpp"
+#include <chemist/dsl/divide.hpp>
+
+/* Testing Strategy.
+ *
+ * Divide is basically a strong type, we just test it can be constructed with
+ * all of the possible const-variations.
+ */
+
+TEMPLATE_LIST_TEST_CASE("Divide", "", test_chemist::binary_types) {
+    using lhs_type = std::tuple_element_t<0, TestType>;
+    using rhs_type = std::tuple_element_t<1, TestType>;
+
+    auto values     = test_chemist::binary_values();
+    auto [lhs, rhs] = std::get<TestType>(values);
+
+    chemist::dsl::Divide<lhs_type, rhs_type> a_xx(lhs, rhs);
+    chemist::dsl::Divide<const lhs_type, rhs_type> a_cx(lhs, rhs);
+    chemist::dsl::Divide<lhs_type, const rhs_type> a_xc(lhs, rhs);
+    chemist::dsl::Divide<const lhs_type, const rhs_type> a_cc(lhs, rhs);
+
+    SECTION("CTors") {
+        REQUIRE(a_xx.lhs() == lhs);
+        REQUIRE(a_xx.rhs() == rhs);
+
+        REQUIRE(a_cx.lhs() == lhs);
+        REQUIRE(a_cx.rhs() == rhs);
+
+        REQUIRE(a_xc.lhs() == lhs);
+        REQUIRE(a_xc.rhs() == rhs);
+
+        REQUIRE(a_cc.lhs() == lhs);
+        REQUIRE(a_cc.rhs() == rhs);
+    }
+}

--- a/tests/cxx/unit_tests/dsl/multiply.cpp
+++ b/tests/cxx/unit_tests/dsl/multiply.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_dsl.hpp"
+#include <chemist/dsl/multiply.hpp>
+
+/* Testing Strategy.
+ *
+ * Multiply is basically a strong type, we just test it can be constructed with
+ * all of the possible const-variations.
+ */
+
+TEMPLATE_LIST_TEST_CASE("Multiply", "", test_chemist::binary_types) {
+    using lhs_type = std::tuple_element_t<0, TestType>;
+    using rhs_type = std::tuple_element_t<1, TestType>;
+
+    auto values     = test_chemist::binary_values();
+    auto [lhs, rhs] = std::get<TestType>(values);
+
+    chemist::dsl::Multiply<lhs_type, rhs_type> a_xx(lhs, rhs);
+    chemist::dsl::Multiply<const lhs_type, rhs_type> a_cx(lhs, rhs);
+    chemist::dsl::Multiply<lhs_type, const rhs_type> a_xc(lhs, rhs);
+    chemist::dsl::Multiply<const lhs_type, const rhs_type> a_cc(lhs, rhs);
+
+    SECTION("CTors") {
+        REQUIRE(a_xx.lhs() == lhs);
+        REQUIRE(a_xx.rhs() == rhs);
+
+        REQUIRE(a_cx.lhs() == lhs);
+        REQUIRE(a_cx.rhs() == rhs);
+
+        REQUIRE(a_xc.lhs() == lhs);
+        REQUIRE(a_xc.rhs() == rhs);
+
+        REQUIRE(a_cc.lhs() == lhs);
+        REQUIRE(a_cc.rhs() == rhs);
+    }
+}

--- a/tests/cxx/unit_tests/dsl/subtract.cpp
+++ b/tests/cxx/unit_tests/dsl/subtract.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_dsl.hpp"
+#include <chemist/dsl/subtract.hpp>
+
+/* Testing Strategy.
+ *
+ * Subtract is basically a strong type, we just test it can be constructed with
+ * all of the possible const-variations.
+ */
+
+TEMPLATE_LIST_TEST_CASE("Subtract", "", test_chemist::binary_types) {
+    using lhs_type = std::tuple_element_t<0, TestType>;
+    using rhs_type = std::tuple_element_t<1, TestType>;
+
+    auto values     = test_chemist::binary_values();
+    auto [lhs, rhs] = std::get<TestType>(values);
+
+    chemist::dsl::Subtract<lhs_type, rhs_type> a_xx(lhs, rhs);
+    chemist::dsl::Subtract<const lhs_type, rhs_type> a_cx(lhs, rhs);
+    chemist::dsl::Subtract<lhs_type, const rhs_type> a_xc(lhs, rhs);
+    chemist::dsl::Subtract<const lhs_type, const rhs_type> a_cc(lhs, rhs);
+
+    SECTION("CTors") {
+        REQUIRE(a_xx.lhs() == lhs);
+        REQUIRE(a_xx.rhs() == rhs);
+
+        REQUIRE(a_cx.lhs() == lhs);
+        REQUIRE(a_cx.rhs() == rhs);
+
+        REQUIRE(a_xc.lhs() == lhs);
+        REQUIRE(a_xc.rhs() == rhs);
+
+        REQUIRE(a_cc.lhs() == lhs);
+        REQUIRE(a_cc.rhs() == rhs);
+    }
+}

--- a/tests/cxx/unit_tests/dsl/term.cpp
+++ b/tests/cxx/unit_tests/dsl/term.cpp
@@ -22,7 +22,9 @@
  * The Term class ensures that it is possible to combine DSL objects without
  * having to overload operator+, operator*, etc. for every object type in the
  * DSL. Thus to test it, it suffices to have a DSL object that derives from
- * Term and then to operate on that object.
+ * Term and then to operate on that object. For this purpose we define an object
+ * "a" which represents adding 4 and 2. We then add, multiply, etc. to "a" the
+ * integer 42.
  */
 
 TEST_CASE("Term") {
@@ -35,8 +37,18 @@ TEST_CASE("Term") {
         REQUIRE((a + forty_two) == corr);
     }
 
+    SECTION("operator-") {
+        chemist::dsl::Subtract<lhs_type, int> corr(a, forty_two);
+        REQUIRE((a - forty_two) == corr);
+    }
+
     SECTION("operator*") {
         chemist::dsl::Multiply<lhs_type, int> corr(a, forty_two);
         REQUIRE((a * forty_two) == corr);
+    }
+
+    SECTION("operator/") {
+        chemist::dsl::Divide<lhs_type, int> corr(a, forty_two);
+        REQUIRE((a / forty_two) == corr);
     }
 }

--- a/tests/cxx/unit_tests/dsl/term.cpp
+++ b/tests/cxx/unit_tests/dsl/term.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "test_dsl.hpp"
+#include <chemist/dsl/dsl.hpp>
+
+/* Testing Strategy.
+ *
+ * The Term class ensures that it is possible to combine DSL objects without
+ * having to overload operator+, operator*, etc. for every object type in the
+ * DSL. Thus to test it, it suffices to have a DSL object that derives from
+ * Term and then to operate on that object.
+ */
+
+TEST_CASE("Term") {
+    int four(4), two(2), forty_two(42);
+    using lhs_type = chemist::dsl::Add<int, int>;
+    lhs_type a(four, two);
+
+    SECTION("operator+") {
+        chemist::dsl::Add<lhs_type, int> corr(a, forty_two);
+        REQUIRE((a + forty_two) == corr);
+    }
+
+    SECTION("operator*") {
+        chemist::dsl::Multiply<lhs_type, int> corr(a, forty_two);
+        REQUIRE((a * forty_two) == corr);
+    }
+}

--- a/tests/cxx/unit_tests/dsl/term_traits.cpp
+++ b/tests/cxx/unit_tests/dsl/term_traits.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "../catch.hpp"
 #include <chemist/dsl/add.hpp>
 #include <chemist/dsl/term_traits.hpp>

--- a/tests/cxx/unit_tests/dsl/term_traits.cpp
+++ b/tests/cxx/unit_tests/dsl/term_traits.cpp
@@ -1,0 +1,78 @@
+#include "../catch.hpp"
+#include <chemist/dsl/add.hpp>
+#include <chemist/dsl/term_traits.hpp>
+
+using namespace chemist;
+
+/* Testing strategy.
+ *
+ * Our goal here is to verify that we implemented the TMP in the TermTraits
+ * class correctly. That really depends on whether or not the template type
+ * parameter T:
+ *
+ * - is const qualified,
+ * - is derived from dsl::Term,
+ * - is a floating point type
+ */
+
+TEST_CASE("TermTraits<char>") {
+    using traits = dsl::TermTraits<char>;
+    STATIC_REQUIRE_FALSE(traits::is_const_v);
+    STATIC_REQUIRE(std::is_same_v<traits::value_type, char>);
+    STATIC_REQUIRE(std::is_same_v<traits::const_reference, const char&>);
+    STATIC_REQUIRE(std::is_same_v<traits::reference, char&>);
+    STATIC_REQUIRE_FALSE(traits::is_dsl_term_v);
+    STATIC_REQUIRE(std::is_same_v<traits::holder_type, char&>);
+}
+
+TEST_CASE("TermTraits<const char>") {
+    using traits = dsl::TermTraits<const char>;
+    STATIC_REQUIRE(traits::is_const_v);
+    STATIC_REQUIRE(std::is_same_v<traits::value_type, char>);
+    STATIC_REQUIRE(std::is_same_v<traits::const_reference, const char&>);
+    STATIC_REQUIRE(std::is_same_v<traits::reference, const char&>);
+    STATIC_REQUIRE_FALSE(traits::is_dsl_term_v);
+    STATIC_REQUIRE(std::is_same_v<traits::holder_type, const char&>);
+}
+
+TEST_CASE("TermTraits<double>") {
+    using traits = dsl::TermTraits<double>;
+    STATIC_REQUIRE_FALSE(traits::is_const_v);
+    STATIC_REQUIRE(std::is_same_v<traits::value_type, double>);
+    STATIC_REQUIRE(std::is_same_v<traits::const_reference, const double&>);
+    STATIC_REQUIRE(std::is_same_v<traits::reference, double&>);
+    STATIC_REQUIRE(traits::is_dsl_term_v);
+    STATIC_REQUIRE(std::is_same_v<traits::holder_type, double>);
+}
+
+TEST_CASE("TermTraits<const double>") {
+    using traits = dsl::TermTraits<const double>;
+    STATIC_REQUIRE(traits::is_const_v);
+    STATIC_REQUIRE(std::is_same_v<traits::value_type, double>);
+    STATIC_REQUIRE(std::is_same_v<traits::const_reference, const double&>);
+    STATIC_REQUIRE(std::is_same_v<traits::reference, const double&>);
+    STATIC_REQUIRE(traits::is_dsl_term_v);
+    STATIC_REQUIRE(std::is_same_v<traits::holder_type, double>);
+}
+
+TEST_CASE("TermTraits<Add<int, double>>") {
+    using op_t   = dsl::Add<int, double>;
+    using traits = dsl::TermTraits<op_t>;
+    STATIC_REQUIRE_FALSE(traits::is_const_v);
+    STATIC_REQUIRE(std::is_same_v<traits::value_type, op_t>);
+    STATIC_REQUIRE(std::is_same_v<traits::const_reference, const op_t&>);
+    STATIC_REQUIRE(std::is_same_v<traits::reference, op_t&>);
+    STATIC_REQUIRE(traits::is_dsl_term_v);
+    STATIC_REQUIRE(std::is_same_v<traits::holder_type, op_t>);
+}
+
+TEST_CASE("TermTraits<const Add<int, double>>") {
+    using op_t   = dsl::Add<int, double>;
+    using traits = dsl::TermTraits<const op_t>;
+    STATIC_REQUIRE(traits::is_const_v);
+    STATIC_REQUIRE(std::is_same_v<traits::value_type, op_t>);
+    STATIC_REQUIRE(std::is_same_v<traits::const_reference, const op_t&>);
+    STATIC_REQUIRE(std::is_same_v<traits::reference, const op_t&>);
+    STATIC_REQUIRE(traits::is_dsl_term_v);
+    STATIC_REQUIRE(std::is_same_v<traits::holder_type, op_t>);
+}

--- a/tests/cxx/unit_tests/dsl/test_dsl.hpp
+++ b/tests/cxx/unit_tests/dsl/test_dsl.hpp
@@ -1,0 +1,44 @@
+#include "../test_helpers.hpp"
+#include <map>
+#include <tuple>
+#include <vector>
+
+/* Testing strategy.
+ *
+ * The DSL component doesn't really care what the types are as long as they
+ * are comparable via operator==. So we test with built-in types:
+ *
+ * - double
+ * - int
+ *
+ * and "user-defined" (actually defined in standard library) types like:
+ *
+ * - std::vector<int>
+ * - std::map<double, int>.
+ *
+ * For the purposes of integration testing, the tests in operator_impl.cpp
+ * will ensure that operators can be added together.
+ */
+
+namespace test_chemist {
+
+/// Provides a tuple of values to initialize unary DSL terms with
+inline auto unary_values() {
+    return std::make_tuple(double{3.14}, int{42}, std::vector<int>{1, 2, 3},
+                           std::map<double, int>{{3.14, 42}});
+}
+
+/// Tuple type returned from unary_values
+using unary_types = decltype(unary_values());
+
+/// Provides a tuple of pairs of values to initialize binary DSL terms with
+inline auto binary_values() {
+    auto [v0, v1, v2, v3] = unary_values();
+    return std::make_tuple(std::pair(v0, v0), std::pair(v0, v1),
+                           std::pair(v2, v3), std::pair(v3, v3));
+}
+
+/// Tuple type returned from binary_values
+using binary_types = decltype(binary_values());
+
+} // namespace test_chemist

--- a/tests/cxx/unit_tests/dsl/test_dsl.hpp
+++ b/tests/cxx/unit_tests/dsl/test_dsl.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "../test_helpers.hpp"
 #include <map>
 #include <tuple>

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/detail_/operator_impl.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/detail_/operator_impl.cpp
@@ -76,6 +76,16 @@ TEST_CASE("OperatorImpl") {
         REQUIRE((t + t) == corr);
     }
 
+    SECTION("operator-") {
+        chemist::dsl::Subtract<t_e_type, t_e_type> corr(t, t);
+        REQUIRE((t - t) == corr);
+    }
+
+    SECTION("operator*") {
+        chemist::dsl::Multiply<t_e_type, t_e_type> corr(t, t);
+        REQUIRE((t * t) == corr);
+    }
+
     SECTION("clone") {
         auto pt = t.clone();
         REQUIRE(pt->are_equal(t));

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/detail_/operator_impl.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/detail_/operator_impl.cpp
@@ -17,6 +17,7 @@
 #include "../../../test_helpers.hpp"
 #include <chemist/chemical_system/electron/electron.hpp>
 #include <chemist/quantum_mechanics/operator/kinetic.hpp>
+#include <chemist/quantum_mechanics/operator/typedefs.hpp>
 
 using namespace chemist;
 using namespace chemist::qm_operator;
@@ -37,8 +38,8 @@ using namespace chemist::qm_operator;
  */
 
 TEST_CASE("OperatorImpl") {
-    Kinetic<Electron> t;
-    Kinetic<ManyElectrons> T{ManyElectrons{2}};
+    t_e_type t;
+    T_e_type T{ManyElectrons{2}};
 
     SECTION("n_electrons") {
         STATIC_REQUIRE(t.n_electrons() == 1);
@@ -59,15 +60,20 @@ TEST_CASE("OperatorImpl") {
         // n.b. Kinetic does not shadow operator== so this goes through
         // OperatorImpl::operator==. Also note it won't compile if the left and
         // right sides have different types
-        REQUIRE(t == Kinetic<Electron>{});
-        REQUIRE(T == Kinetic<ManyElectrons>{ManyElectrons{2}});
-        REQUIRE_FALSE(T == Kinetic<ManyElectrons>{ManyElectrons{1}});
+        REQUIRE(t == t_e_type{});
+        REQUIRE(T == T_e_type{ManyElectrons{2}});
+        REQUIRE_FALSE(T == T_e_type{ManyElectrons{1}});
     }
 
     SECTION("operator!=") {
-        REQUIRE_FALSE(t != Kinetic<Electron>{});
-        REQUIRE_FALSE(T != Kinetic<ManyElectrons>{ManyElectrons{2}});
-        REQUIRE(T != Kinetic<ManyElectrons>{ManyElectrons{1}});
+        REQUIRE_FALSE(t != t_e_type{});
+        REQUIRE_FALSE(T != T_e_type{ManyElectrons{2}});
+        REQUIRE(T != T_e_type{ManyElectrons{1}});
+    }
+
+    SECTION("operator+") {
+        chemist::dsl::Add<t_e_type, t_e_type> corr(t, t);
+        REQUIRE((t + t) == corr);
     }
 
     SECTION("clone") {
@@ -79,12 +85,12 @@ TEST_CASE("OperatorImpl") {
     }
 
     SECTION("are_equal") {
-        REQUIRE(t.are_equal(Kinetic<Electron>{}));
+        REQUIRE(t.are_equal(t_e_type{}));
         REQUIRE_FALSE(t.are_equal(T));
     }
 
     SECTION("are_different") {
-        REQUIRE_FALSE(t.are_different(Kinetic<Electron>{}));
+        REQUIRE_FALSE(t.are_different(t_e_type{}));
         REQUIRE(t.are_different(T));
     }
 }


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
We're going to need DSL semantics for the operators, wavefunctions, and (possibly) the bra-kets. I *think* I figured out a way to do most of it all at once by basically decoupling the starting and ending points of the DSL from the framework. With this strategy the DSL starts in the primitives (the operator, wavefunction, or bra-ket objects), via overloads of methods such as `operator+`, and ends when a `dsl::Term` object is assigned to a primitive.  

This PR adds that DSL and integration tests it via the operator component.

**TODOs**
The usual: documentation, testing, and more features (notably scaling by a floating-point value).
