### PR TITLE
Adds a density operator

### DIFF
--- a/include/chemist/chemist.hpp
+++ b/include/chemist/chemist.hpp
@@ -27,6 +27,8 @@
 
 #include <chemist/basis_set/basis_set.hpp>
 #include <chemist/chemical_system/chemical_system.hpp>
+#include <chemist/density/decomposable_density.hpp>
+#include <chemist/density/density.hpp>
 #include <chemist/electron/electron.hpp>
 #include <chemist/enums.hpp>
 #include <chemist/fragmenting/fragmenting.hpp>

--- a/include/chemist/quantum_mechanics/operator/density.hpp
+++ b/include/chemist/quantum_mechanics/operator/density.hpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <chemist/quantum_mechanics/operator/detail_/operator_impl.hpp>
+#include <chemist/quantum_mechanics/wavefunction/determinant.hpp>
+
+namespace chemist::qm_operator {
+
+/** @brief  An operator for the probability density of a series of particles.
+ *
+ *  @tparam OrbitalsType The type of the vector space spanned by the one-
+ *                       particle basis functions.
+ *  @tparam Particles The particles described by this operator.
+ *
+ *  In quantum mechanics, the density operator is a projection operator that
+ *  projects onto the state of the system. For the state @f$\ket{\Psi}@f$ this
+ *  has the form:
+ *  @f[
+ *     \widehat{\rho} = \ket{\Psi}\bra{\Psi}.
+ *  @f]
+ *  In the more general case when @f$\ket{Psi}@f$ is an ensemble of @f$m@f$
+ *  states this becomes:
+ *  @f[
+ *      \widehat{\rho} = \sum_{i=1}^m w_i\ket{\psi_i}\bra{\psi_i},
+ *  @f]
+ *  where @f$w_i@f$ is the weight of the @f$i@f$-th state, @$\bra{\psi_i}@f$, in
+ *  the ensemble.
+ *
+ */
+template<typename OrbitalsType, typename... Particles>
+class Density
+  : public detail_::OperatorImpl<Density<OrbitalsType, Particles...>,
+                                 Particles...> {
+private:
+    /// Type of *this
+    using my_type = Density<OrbitalsType, Particles...>;
+
+    /// Type of the implementation
+    using impl_type = detail_::OperatorImpl<my_type, Particles...>;
+
+public:
+    /// Pull in base class's types
+    ///@{
+    using typename impl_type::base_pointer;
+    using typename impl_type::const_base_reference;
+    using typename impl_type::visitor_reference;
+    ///@}
+
+    /// The type used to store the weight of each state
+    using weight_type = double;
+
+    /// The type used to store the weights of each state
+    using weight_vector_type = std::vector<weight_type>;
+
+    /// Type acting like a mutable reference to an object of type weight_vector
+    using weight_vector_reference = weight_vector_type&;
+
+    /// Type acting lik a read-only reference to an object of type weight_vector
+    using const_weight_vector_reference = const weight_vector_type&;
+
+    /// The type of one-particle functions comprising *this
+    using orbitals_type = OrbitalsType;
+
+    /// Type acting like a reference to a mutable orbitals_type object
+    using orbitals_reference = orbitals_type&;
+
+    /// Type acting like a reference to a read-only orbitals_type object
+    using const_orbitals_reference = const orbitals_type&;
+
+    /// Type used for indexing and offsets
+    using size_type = typename weight_vector_type::size_type;
+
+    /** @brief Creates the density of an empty system.
+     *
+     *  Objects created by this ctor are usually placeholders and wil have their
+     *  state assigned to them later.
+     *
+     *  @throw None No throw guarantee.
+     */
+    Density() noexcept = default;
+
+    /** @brief Creates a density operator with the provided ensemble.
+     *
+     *  This ctor creates a density operator where the @f$i@f$-th projection is
+     *  `weights[i] * orbitals[i] * orbitals[i].adjoint()`.
+     *
+     *  @param[in] orbitals The basis set the density operator is expressed in.
+     *  @param[in] weights The weight of each basis function in the ensemble.
+     *
+     *  @throw std::runtime_error if the size of orbitals is not the same as
+     *                            the size of weights.
+     */
+    Density(orbitals_type orbitals, weight_vector_type weights) :
+      m_weights_(std::move(weights)), m_orbitals_(std::move(orbitals)) {
+        if(m_weights_.size() != m_orbitals_.size())
+            throw std::runtime_error("Must provide one weight per orbital");
+    }
+
+    /** @brief Creates a density operator with the provided ensemble
+     *
+     *  @tparam T The input type of the weights
+     *
+     *  In many cases the weights being used to initialize *this are not stored
+     *  as `weight_type` objects (e.g., when weights map to occupations they are
+     *  often integers). This ctor facilitates converting non-`weight_type`
+     *  weights into `weight_type` weights. This ctor converts @p weights and
+     *  then dispatches to the value ctor.
+     *
+     *  @param[in] orbitals The one-electron wavefunctions *this is based on.
+     *  @param[in] weights The weights of each orbital in the ensemble.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the memory for
+     *                        the converted weights. Strong throw guarantee.
+     */
+    template<typename T>
+    Density(orbitals_type orbitals, std::vector<T> weights) :
+      Density(std::move(orbitals),
+              weight_vector_type(weights.begin(), weights.end())) {}
+
+    /** @brief Forms the density from the many-particle wavefunction.
+     *
+     *  The `m` particle wavefunction can be converted to an
+     *  `n=sizeof...(Particles)` particle density by taking the inner product
+     *  over the `m-n` particles that are not part of the density. This ctor
+     *  initializes *this by contracting over the `m-n` particles.
+     *
+     *  @param[in] wf The many-particle wavefunction of the system.
+     *
+     *  @throw std::bad_alloc if there is a problem copying the state from
+     *                        @p wf. Strong throw guarantee.
+     */
+    explicit Density(const wavefunction::Determinant<orbitals_type>& wf) :
+      Density(wf.orbitals(), wf.occupations()) {
+        // I think what we have only works for the one-particle density operator
+        static_assert(sizeof...(Particles) == 1);
+    }
+
+    // -------------------------------------------------------------------------
+    // -- Getters and Setters
+    // -------------------------------------------------------------------------
+
+    /** @brief Provides mutable access to the orbitals.
+     *
+     *  This method can be used to inspect and modify the orbitals forming
+     *  *this. If you add/remove an orbital you are expected to add/remove the
+     *  corresponding weight as well. This method will NOT check that this is
+     *  the case.
+     *
+     *  @return The orbitals forming *this.
+     *
+     *  @throw None No throw guarantee.
+     */
+    orbitals_reference orbitals() noexcept { return m_orbitals_; }
+
+    /** @brief Provides read-only access to the orbitals.
+     *
+     *  This method is the same as the non-const version except that the result
+     *  is immutable.
+     *
+     *  @return The orbitals forming *this.
+     *
+     *  @throw None No throw guarantee.
+     */
+    const_orbitals_reference orbitals() const noexcept { return m_orbitals_; }
+
+    /** @brief Provides mutable access to the weights of the ensemble.
+     *
+     *  This method provides mutable access to the weights of the ensemble. If
+     *  you add/remove a weight you are expected to also add/remove the
+     *  corresponding orbital.
+     *
+     *  @return The weights of the states forming *this.
+     *
+     *  @throw None No throw guarantee.
+     */
+    weight_vector_reference weights() noexcept { return m_weights_; }
+
+    /** @brief Provides read-only access to the weights of the ensemble.
+     *
+     *  This method is the same as the non-const version except that the
+     *  resulting weights are immutable.
+     *
+     *  @return The weights of the ensemble forming *this.
+     *
+     *  @throw None No throw guarantee.
+     */
+    const_weight_vector_reference weights() const noexcept {
+        return m_weights_;
+    }
+
+    /** @brief Returns the number of states in *this.
+     *
+     *  This method is used to determine the number of states forming this
+     *  density operator.
+     *
+     *  @return The number of states comprising the ensemble.
+     *
+     *  @throw None No throw guarantee.
+     */
+    size_type size() const noexcept { return m_orbitals_.size(); }
+
+    // -------------------------------------------------------------------------
+    // -- Utility methods
+    // -------------------------------------------------------------------------
+
+    /** @brief Determines if *this is value equal to @p rhs.
+     *
+     *  Two density operators are value equal if they contain the same number
+     *  of states in the ensemble, if the @f$i@f$-th weight in *this is value
+     *  equal to the @f$i@f$-ith weight in @p rhs, and if the @f$i@f$-th state
+     *  in *this is value equal to the @f$i@f$-th state in *this.
+     *
+     *  @param[in] rhs The operator to compare to.
+     *
+     *  @return True if *this is value equal to @p rhs and false otherwise.
+     *
+     *  @throw None No throw guarantee.
+     */
+    bool operator==(const Density& rhs) const noexcept {
+        return std::tie(m_weights_, m_orbitals_) ==
+               std::tie(rhs.m_weights_, rhs.m_orbitals_);
+    }
+
+    /** @brief Determines if *this is different from @p rhs.
+     *
+     *  This class defines different as "not value equal." See the description
+     *  for operator== for the definition of value equality.
+     *
+     *  @param[in] rhs The density operator to compare to.
+     *
+     *  @return False if *this is value equal to @p rhs and true otherwise.
+     *
+     *  @throw None No throw guarantee.
+     */
+    bool operator!=(const Density& rhs) const noexcept {
+        return !((*this) == rhs);
+    }
+
+private:
+    /// Ensemble weights of the orbitals
+    weight_vector_type m_weights_;
+
+    /// The orbitals
+    orbitals_type m_orbitals_;
+};
+
+} // namespace chemist::qm_operator

--- a/include/chemist/quantum_mechanics/operator/operator.hpp
+++ b/include/chemist/quantum_mechanics/operator/operator.hpp
@@ -17,6 +17,7 @@
 #pragma once
 #include <chemist/quantum_mechanics/operator/core_hamiltonian.hpp>
 #include <chemist/quantum_mechanics/operator/coulomb.hpp>
+#include <chemist/quantum_mechanics/operator/density.hpp>
 #include <chemist/quantum_mechanics/operator/electronic_hamiltonian.hpp>
 #include <chemist/quantum_mechanics/operator/exchange.hpp>
 #include <chemist/quantum_mechanics/operator/exchange_correlation.hpp>

--- a/include/chemist/quantum_mechanics/operator/operator_fwd.hpp
+++ b/include/chemist/quantum_mechanics/operator/operator_fwd.hpp
@@ -23,6 +23,9 @@
  */
 
 namespace chemist::qm_operator {
+template<typename T, typename... Particles>
+class Density;
+
 template<typename T>
 class Kinetic;
 

--- a/include/chemist/quantum_mechanics/operator/operator_visitor.hpp
+++ b/include/chemist/quantum_mechanics/operator/operator_visitor.hpp
@@ -18,7 +18,7 @@
 #include <chemist/electron/electron.hpp>
 #include <chemist/nucleus/nucleus.hpp>
 #include <chemist/quantum_mechanics/operator/operator_fwd.hpp>
-
+#include <chemist/quantum_mechanics/wavefunction/wavefunction_fwd.hpp>
 namespace chemist::qm_operator {
 
 #define OVERLOAD(...) virtual void run(__VA_ARGS__&)
@@ -74,6 +74,8 @@ public:
      */
     OperatorVisitor(bool should_throw = true) : m_throw_(should_throw) {}
 
+    OVERLOADS(Density<wavefunction::MOs, Electron>);
+    OVERLOADS(Density<wavefunction::CMOs, Electron>);
     ONE_PARTICLE_OVERLOADS(Kinetic);
     TWO_PARTICLE_OVERLOADS(Coulomb);
     TWO_PARTICLE_OVERLOADS(Exchange);

--- a/include/chemist/quantum_mechanics/wavefunction/determinant.hpp
+++ b/include/chemist/quantum_mechanics/wavefunction/determinant.hpp
@@ -63,6 +63,9 @@ public:
     /// A read-only reference to an object of type orbital_index_set_type
     using const_orbital_index_set_reference = const orbital_index_set_type&;
 
+    /// Type of a vector holding orbital occupations
+    using occupation_vector_type = std::vector<unsigned short>;
+
     /** @brief Creates a determinant for a zero particle system.
      *
      *  The default ctor will create a Determinant which is associated with an
@@ -118,6 +121,27 @@ public:
      */
     const_orbital_index_set_reference orbital_indices() const {
         return m_occupied_;
+    }
+
+    /** @brief Returns the occupation number vector for *this.
+     *
+     *  `orbital_indices` returns an array containing the offsets of the
+     *  occupied orbitals. This function returns an array which is "number of
+     *  orbitals" long such that the  `i`-th element of return is the occupation
+     *  of orbital `i`.
+     *
+     *  @return An array providing the occupations of each orbital.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the return.
+     *                        Strong throw guarantee.
+     */
+    occupation_vector_type occupations() const {
+        occupation_vector_type rv(m_orbitals_.size(), 0);
+        // TODO: We need to generalize this using TMP, for now crash if not CMOs
+        static_assert(std::is_same_v<OneParticleBasis, CMOs> ||
+                      std::is_same_v<OneParticleBasis, MOs>);
+        for(auto i : orbital_indices()) rv[i] = 2;
+        return rv;
     }
 
     /** @brief Returns the set of orbitals from which the occupied orbitals are

--- a/include/chemist/quantum_mechanics/wavefunction/wavefunction_fwd.hpp
+++ b/include/chemist/quantum_mechanics/wavefunction/wavefunction_fwd.hpp
@@ -25,6 +25,7 @@
 namespace chemist::wavefunction {
 
 class AOs;
+class CMOs;
 template<typename OneParticleBasis>
 class Determinant;
 class MOs;

--- a/src/chemist/quantum_mechanics/operator/operator_visitor.cpp
+++ b/src/chemist/quantum_mechanics/operator/operator_visitor.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <chemist/quantum_mechanics/operator/operator.hpp>
-
+#include <chemist/quantum_mechanics/wavefunction/wavefunction.hpp>
 namespace chemist::qm_operator {
 
 #define OVERLOAD(...)                                         \
@@ -47,6 +47,8 @@ namespace chemist::qm_operator {
     OVERLOADS(T<ManyElectrons, Nuclei>);        \
     OVERLOADS(T<Nuclei, Nuclei>)
 
+OVERLOADS(Density<wavefunction::MOs, Electron>);
+OVERLOADS(Density<wavefunction::CMOs, Electron>);
 ONE_PARTICLE_OVERLOADS(Kinetic);
 TWO_PARTICLE_OVERLOADS(Coulomb);
 TWO_PARTICLE_OVERLOADS(Exchange);

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/density.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/density.cpp
@@ -1,0 +1,105 @@
+#include "../../test_helpers.hpp"
+#include "../test_qm.hpp"
+#include <chemist/quantum_mechanics/quantum_mechanics.hpp>
+
+using namespace chemist;
+
+TEST_CASE("Density<MOs, Electron>") {
+    using orbital_type  = wavefunction::MOs;
+    using particle_type = Electron;
+    using density_type  = qm_operator::Density<orbital_type, particle_type>;
+    using weight_type   = typename density_type::weight_type;
+
+    orbital_type defaulted_mos;
+    auto h2_mos = test_chemist::h2_mos();
+
+    std::vector<weight_type> defaulted_weights;
+    std::vector<weight_type> h2_weights{2.0, 0.0};
+
+    density_type defaulted;
+    density_type defaulted_value(defaulted_mos, defaulted_weights);
+    density_type value(h2_mos, h2_weights);
+
+    SECTION("Ctors") {
+        SECTION("Default") {
+            REQUIRE(defaulted.size() == 0);
+            REQUIRE(defaulted.orbitals() == defaulted_mos);
+            REQUIRE(defaulted.weights() == defaulted_weights);
+        }
+
+        SECTION("Value") {
+            REQUIRE(defaulted_value.size() == 0);
+            REQUIRE(defaulted_value.orbitals() == defaulted_mos);
+            REQUIRE(defaulted_value.weights() == defaulted_weights);
+
+            REQUIRE(value.size() == 2);
+            REQUIRE(value.orbitals() == h2_mos);
+            REQUIRE(value.weights() == h2_weights);
+
+            using error_t = std::runtime_error;
+            REQUIRE_THROWS_AS(density_type(h2_mos, defaulted_weights), error_t);
+        }
+
+        SECTION("Value (wrong weight type)") {
+            std::vector<int> occupations{2, 0};
+            density_type value2(h2_mos, occupations);
+            REQUIRE(value2.size() == 2);
+            REQUIRE(value2.orbitals() == h2_mos);
+            REQUIRE(value2.weights() == h2_weights);
+        }
+
+        SECTION("Determinant") {
+            using determinant_type = wavefunction::Determinant<orbital_type>;
+            using orbital_index_set_type =
+              typename determinant_type::orbital_index_set_type;
+            orbital_index_set_type occs{0};
+            determinant_type Psi(occs, h2_mos);
+            density_type value2(Psi);
+            REQUIRE(value2.size() == 2);
+            REQUIRE(value2.orbitals() == h2_mos);
+            REQUIRE(value2.weights() == h2_weights);
+        }
+
+        test_chemist::test_copy_and_move(defaulted, defaulted_value, value);
+    }
+
+    SECTION("orbitals()") {
+        REQUIRE(defaulted.orbitals() == defaulted_mos);
+        REQUIRE(value.orbitals() == h2_mos);
+    }
+
+    SECTION("orbitals() const") {
+        REQUIRE(std::as_const(defaulted).orbitals() == defaulted_mos);
+        REQUIRE(std::as_const(value).orbitals() == h2_mos);
+    }
+
+    SECTION("weights()") {
+        REQUIRE(defaulted.weights() == defaulted_weights);
+        REQUIRE(value.weights() == h2_weights);
+    }
+
+    SECTION("weights() const") {
+        REQUIRE(std::as_const(defaulted).weights() == defaulted_weights);
+        REQUIRE(std::as_const(value).weights() == h2_weights);
+    }
+
+    SECTION("operator==") {
+        REQUIRE(defaulted == density_type{});
+        REQUIRE(defaulted == defaulted_value);
+        REQUIRE_FALSE(defaulted == value);
+
+        REQUIRE(value == density_type(h2_mos, h2_weights));
+
+        typename wavefunction::MOs::transform_type c{{1.0, 0.0}, {0.0, 1.0}};
+        wavefunction::MOs mos2(h2_mos.from_space(), c);
+        REQUIRE_FALSE(value == density_type(mos2, h2_weights));
+
+        std::vector<weight_type> weights2{0.0, 2.0};
+        REQUIRE_FALSE(value == density_type(h2_mos, weights2));
+    }
+
+    SECTION("operator!=") {
+        REQUIRE(value != defaulted);
+        REQUIRE_FALSE(defaulted != density_type{});
+    }
+}

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/density.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/density.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "../../test_helpers.hpp"
 #include "../test_qm.hpp"
 #include <chemist/quantum_mechanics/quantum_mechanics.hpp>

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/detail_/unpack_linear_combination.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/detail_/unpack_linear_combination.cpp
@@ -16,7 +16,7 @@
 
 #include "../../../catch.hpp"
 #include <chemist/quantum_mechanics/operator/detail_/unpack_linear_combination.hpp>
-#include <chemist/quantum_mechanics/operator/operator.hpp>
+#include <chemist/quantum_mechanics/quantum_mechanics.hpp>
 
 using namespace chemist::qm_operator;
 

--- a/tests/cxx/unit_tests/quantum_mechanics/wavefunction/determinant.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/wavefunction/determinant.cpp
@@ -57,6 +57,13 @@ TEST_CASE("Determinant<MOs>") {
         REQUIRE(std::as_const(value).orbital_indices() == i0);
     }
 
+    SECTION("occupations") {
+        using occ_vector = typename determinant_type::occupation_vector_type;
+        occ_vector occ_empty, occ_value{2, 0};
+        REQUIRE(defaulted.occupations() == occ_empty);
+        REQUIRE(value.occupations() == occ_value);
+    }
+
     SECTION("orbitals()") {
         REQUIRE(defaulted.orbitals() == defaulted_mos);
         REQUIRE(value.orbitals() == mos);


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
We had a class which represents the physical entity which is a density, but we did not have a density operator. It should be noted we need both. The density operator is needed to form the
physical density via a `BraKet` object.

**TODOs**
None. Should be r2g if it passes CI and I remembered to test everything.
