### PR TITLE
minor features

### DIFF
--- a/include/chemist/molecule/molecule_class.hpp
+++ b/include/chemist/molecule/molecule_class.hpp
@@ -15,6 +15,7 @@
  */
 
 #pragma once
+#include <chemist/electron/many_electrons.hpp>
 #include <chemist/molecule/atom.hpp>
 #include <chemist/nucleus/nuclei_view.hpp>
 #include <chemist/traits/molecule_traits.hpp>
@@ -60,6 +61,9 @@ public:
     /// Type of a class defining the types for the Nuclei part of *this
     using nuclei_traits = typename traits_type::nuclei_traits;
 
+    /// Type of a class defining the types for the electronic part of *this
+    using many_electrons_traits = typename traits_type::many_electrons_traits;
+
     /// Type of a class defining the types for an Atom object
     using atom_traits = typename traits_type::atom_traits;
 
@@ -77,6 +81,9 @@ public:
 
     /// Type of a read-only reference to the set of nuclei
     using const_nuclei_reference = typename nuclei_traits::const_view_type;
+
+    /// Type of an object representing the electrons
+    using many_electrons_type = typename many_electrons_traits::value_type;
 
     /// Type of a nucleus
     using value_type = typename nuclei_type::value_type;
@@ -257,6 +264,19 @@ public:
      *                            guarantee.
      */
     const_nuclei_reference nuclei() const;
+
+    /** @brief Returns the electronic part of *this.
+     *
+     *  A molecule is a collection of electrons and nuclei. This method returns
+     *  the set of electrons.
+     *
+     *  @return An object containing the electrons.
+     *
+     *  @throw None No throw guarantee.
+     */
+    many_electrons_type electrons() const {
+        return many_electrons_type{n_electrons()};
+    }
 
     /** @brief The number of electrons in this molecule.
      *
@@ -503,14 +523,14 @@ void Molecule::save(Archive& ar) const {
 template<typename Archive>
 void Molecule::load(Archive& ar) {
     bool has_pimpl = false;
-    ar& has_pimpl;
+    ar & has_pimpl;
     if(has_pimpl) {
         charge_type q;
         multiplicity_type m;
         nuclei_type nuclei;
-        ar& q;
-        ar& m;
-        ar& nuclei;
+        ar & q;
+        ar & m;
+        ar & nuclei;
         Molecule(q, m, nuclei).swap(*this);
     }
 }

--- a/include/chemist/molecule/molecule_view.hpp
+++ b/include/chemist/molecule/molecule_view.hpp
@@ -85,6 +85,9 @@ public:
     /// Type of the struct defining types for the Nuclei piece of *this
     using nuclei_traits = typename traits_type::nuclei_traits;
 
+    /// Type of the struct defining types for the electrons
+    using many_electrons_traits = typename traits_type::many_electrons_traits;
+
     /// Non-cv-qualified type of the Molecule object *this aliases
     using molecule_type = typename traits_type::value_type;
 
@@ -96,6 +99,9 @@ public:
 
     /// Type of a read-only reference to a Nuclei object
     using const_nuclei_reference = typename nuclei_traits::const_view_type;
+
+    /// Type of the object holding the electronic part of *this
+    using many_electrons_type = typename many_electrons_traits::value_type;
 
     /// Type of a nucleus object
     using value_type = typename atom_traits::nucleus_traits::value_type;
@@ -297,6 +303,18 @@ public:
      *
      */
     const_nuclei_reference nuclei() const;
+
+    /** @brief Returns the electronic piece of *this.
+     *
+     *  This method can be used to retrieve the electrons of *this.braket
+     *
+     *  @return An object which contains the electronic piece of *this.
+     *
+     *  @throw None No throw guarantee.
+     */
+    many_electrons_type electrons() const {
+        return many_electrons_type(n_electrons());
+    }
 
     /** @brief How many electrons does the aliased Molecule have?
      *

--- a/include/chemist/quantum_mechanics/operator/detail_/linear_combination_impl.hpp
+++ b/include/chemist/quantum_mechanics/operator/detail_/linear_combination_impl.hpp
@@ -93,6 +93,22 @@ public:
         return *(m_terms_.at(i).second);
     }
 
+    /** @brief Adds a term to the operator.
+     *
+     *  This method is used to add an operator to *this. The term is assumed
+     *  to be added to the terms already contained in *this (i.e., make @p c
+     *  negative if you want the term be subtracted).
+     *
+     *  @param[in] c  The weight of the term.
+     *  @param[in] op The term.
+     *
+     *  @throw std::bad_alloc if there is a problem adding the term. Strong
+     *                        throw guarantee.
+     */
+    void emplace_back(coefficient_type c, base_pointer op) {
+        m_terms_.emplace_back(std::make_pair(c, std::move(op)));
+    }
+
     /** @brief Is *this the same as @p rhs?
      *
      *  Two linear combinations are value equal if they:

--- a/include/chemist/traits/molecule_traits.hpp
+++ b/include/chemist/traits/molecule_traits.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <chemist/traits/chemist_class_traits.hpp>
+#include <chemist/traits/electron_traits.hpp>
 #include <chemist/traits/nucleus_traits.hpp>
 
 namespace chemist {
@@ -40,6 +41,7 @@ struct ChemistClassTraits<Atom> {
     using multiplicity_pointer         = multiplicity_type*;
     using const_multiplicity_pointer   = const multiplicity_type*;
     using nucleus_traits               = ChemistClassTraits<Nucleus>;
+    using electron_traits              = ChemistClassTraits<Electron>;
 };
 
 template<>
@@ -55,34 +57,37 @@ struct ChemistClassTraits<const Atom> {
     using multiplicity_pointer         = const multiplicity_type*;
     using const_multiplicity_pointer   = const multiplicity_type*;
     using nucleus_traits               = ChemistClassTraits<const Nucleus>;
+    using electron_traits              = ChemistClassTraits<const Electron>;
 };
 
 template<>
 struct ChemistClassTraits<Molecule> {
-    using value_type           = Molecule;
-    using reference            = value_type&;
-    using const_reference      = const value_type&;
-    using view_type            = MoleculeView<value_type>;
-    using const_view_type      = MoleculeView<const value_type>;
-    using charge_type          = short;
-    using charge_pointer       = charge_type*;
-    using const_charge_pointer = const charge_type*;
-    using atom_traits          = ChemistClassTraits<Atom>;
-    using nuclei_traits        = ChemistClassTraits<Nuclei>;
+    using value_type            = Molecule;
+    using reference             = value_type&;
+    using const_reference       = const value_type&;
+    using view_type             = MoleculeView<value_type>;
+    using const_view_type       = MoleculeView<const value_type>;
+    using charge_type           = short;
+    using charge_pointer        = charge_type*;
+    using const_charge_pointer  = const charge_type*;
+    using atom_traits           = ChemistClassTraits<Atom>;
+    using nuclei_traits         = ChemistClassTraits<Nuclei>;
+    using many_electrons_traits = ChemistClassTraits<ManyElectrons>;
 };
 
 template<>
 struct ChemistClassTraits<const Molecule> {
-    using value_type           = Molecule;
-    using reference            = const value_type&;
-    using const_reference      = const value_type&;
-    using view_type            = MoleculeView<const value_type>;
-    using const_view_type      = MoleculeView<const value_type>;
-    using charge_type          = short;
-    using charge_pointer       = const charge_type*;
-    using const_charge_pointer = const charge_type*;
-    using atom_traits          = ChemistClassTraits<const Atom>;
-    using nuclei_traits        = ChemistClassTraits<const Nuclei>;
+    using value_type            = Molecule;
+    using reference             = const value_type&;
+    using const_reference       = const value_type&;
+    using view_type             = MoleculeView<const value_type>;
+    using const_view_type       = MoleculeView<const value_type>;
+    using charge_type           = short;
+    using charge_pointer        = const charge_type*;
+    using const_charge_pointer  = const charge_type*;
+    using atom_traits           = ChemistClassTraits<const Atom>;
+    using nuclei_traits         = ChemistClassTraits<const Nuclei>;
+    using many_electrons_traits = ChemistClassTraits<const ManyElectrons>;
 };
 
 } // namespace chemist

--- a/tests/cxx/unit_tests/molecule/molecule.cpp
+++ b/tests/cxx/unit_tests/molecule/molecule.cpp
@@ -149,6 +149,13 @@ TEST_CASE("Molecule Class") {
         REQUIRE(std::as_const(hd).nuclei() == corr_nuclei);
     }
 
+    SECTION("electrons") {
+        using electrons_type = Molecule::many_electrons_type;
+        REQUIRE(mol.electrons() == electrons_type{1});
+        REQUIRE(hd.electrons() == electrons_type{2});
+        REQUIRE(qm.electrons() == electrons_type{1});
+    }
+
     SECTION("n_electrons") {
         REQUIRE(mol.n_electrons() == 1);
         REQUIRE(hd.n_electrons() == 2);

--- a/tests/cxx/unit_tests/molecule/molecule_view.cpp
+++ b/tests/cxx/unit_tests/molecule/molecule_view.cpp
@@ -135,6 +135,13 @@ TEMPLATE_LIST_TEST_CASE("MoleculeView", "", types2test) {
         REQUIRE(std::as_const(value).nuclei() == value_mol.nuclei());
     }
 
+    SECTION("electrons") {
+        using many_electrons_type = typename view_type::many_electrons_type;
+        REQUIRE(defaulted.electrons() == many_electrons_type(0));
+        REQUIRE(empty_value.electrons() == many_electrons_type(0));
+        REQUIRE(value.electrons() == many_electrons_type(3));
+    }
+
     SECTION("n_electrons") {
         REQUIRE(defaulted.n_electrons() == 0);
         REQUIRE(empty_value.n_electrons() == 0);

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/detail_/linear_combination_impl.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/detail_/linear_combination_impl.cpp
@@ -85,6 +85,14 @@ TEST_CASE("LinearCombinationImpl") {
         REQUIRE_THROWS_AS(std::as_const(H).get_operator(4), std::out_of_range);
     }
 
+    SECTION("emplace_back") {
+        defaulted.emplace_back(H.coefficient(0), H.get_operator(0).clone());
+        defaulted.emplace_back(H.coefficient(1), H.get_operator(1).clone());
+        defaulted.emplace_back(H.coefficient(2), H.get_operator(2).clone());
+        defaulted.emplace_back(H.coefficient(3), H.get_operator(3).clone());
+        REQUIRE(defaulted == H);
+    }
+
     SECTION("clone") {
         REQUIRE(defaulted.clone()->are_equal(defaulted));
         REQUIRE(H.clone()->are_equal(H));


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This PR adds a couple missing features:
- Ability to get a `ManyElectrons` object from a `Molecule` object.
- Ability to get a `ManyElectrons` object from a `MoleculeView` object.
- Ability to add terms to operators which are linear combinations (e.g., `Hamiltonian`).

**TODOs**
None. This is r2g.
