### PR TITLE
`bra_ket_base_type` Default Value

### DIFF
--- a/include/chemist/quantum_mechanics/braket/braket_class.hpp
+++ b/include/chemist/quantum_mechanics/braket/braket_class.hpp
@@ -37,8 +37,8 @@ namespace detail_ {
  */
 template<typename BraType, typename OperatorType, typename KetType>
 using bra_ket_base_type =
-  std::conditional_t<is_tensor_representation_v<BraType, OperatorType, KetType>,
-                     TensorRepresentation, TensorElement<double>>;
+  std::conditional_t<is_tensor_element_v<BraType, OperatorType, KetType>,
+                     TensorElement<double>, TensorRepresentation>;
 } // namespace detail_
 
 /** @brief Specifies the calculation (or a piece of it) that the user wants.


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Currently, the base type for `BraKet` defaults to `TensorElement<double>` unless the `BraType` and `KetType` are both derived from `Wavefunction`. This is awkward for DSL terms like `chemist::dsl::Multiply<aos, aos>` which represent something that is `Wavefunction`-like but are derived from `chemist::dsl::Term`. Given that a tensor element can be represented as a single element tensor, it's simpler to have the base type be a `TensorRepresentation` unless the components explicitly evaluate to `TensorElement<double>`. This PR changes the behavior accordingly.
