### PR TITLE
Add implicit BraKet conversions

### DIFF
--- a/include/chemist/quantum_mechanics/braket/braket_class.hpp
+++ b/include/chemist/quantum_mechanics/braket/braket_class.hpp
@@ -39,6 +39,7 @@ template<typename BraType, typename OperatorType, typename KetType>
 using bra_ket_base_type =
   std::conditional_t<is_tensor_element_v<BraType, OperatorType, KetType>,
                      TensorElement<double>, TensorRepresentation>;
+
 } // namespace detail_
 
 /** @brief Specifies the calculation (or a piece of it) that the user wants.
@@ -55,6 +56,19 @@ private:
     /// Type of a pointer to a base operator
     using operator_base_pointer =
       typename chemist::qm_operator::OperatorBase::base_pointer;
+
+    template<typename FromBraType, typename FromOpType, typename FromKetType>
+    static constexpr auto braket_is_convertible_v =
+      (std::is_convertible_v<FromBraType*, BraType*> &&
+       std::is_convertible_v<FromOpType*, OperatorType*> &&
+       std::is_convertible_v<FromKetType*, KetType*>);
+
+    // template<typename OtherType>
+    // static constexpr auto is_my_type_v = std::is_same_t<my_type, OtherType>;
+
+    template<typename BraType2, typename OperatorType2, typename KetType2>
+    using enable_if_conversion_t = std::enable_if_t<
+      braket_is_convertible_v<BraType2, OperatorType2, KetType2>>;
 
 public:
     /// Type *this inherits from
@@ -125,6 +139,12 @@ public:
                clone_op_(std::forward<OperatorType2>(op)),
                std::forward<KetType2>(ket)} {}
 
+    template<
+      typename BraType2, typename OperatorType2, typename KetType2,
+      typename = enable_if_conversion_t<BraType2, OperatorType2, KetType2>>
+    BraKet(const BraKet<BraType2, OperatorType2, KetType2>& other) :
+      BraKet(other.bra(), other.op(), other.ket()) {}
+
     /** @brief Initializes *this with a deep copy of @p other.
      *
      *  @param[in] other The BraKet to copy.
@@ -133,7 +153,7 @@ public:
      *                        throw guarantee.
      */
     BraKet(const BraKet& other) :
-      BraKet(other.bra(), other.op(), other.ket()){};
+      BraKet(other.bra(), other.op(), other.ket()) {};
 
     /** @brief Initializes *this by taking the state from @p other.
      *

--- a/tests/cxx/unit_tests/quantum_mechanics/braket/braket_class.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/braket/braket_class.cpp
@@ -79,6 +79,13 @@ TEMPLATE_LIST_TEST_CASE("BraKet", "", bra_ket_tuples) {
             REQUIRE(o_ij.op() == op);
             REQUIRE(o_ij.ket() == ket);
         }
+
+        SECTION("convert") {
+            BraKet<AOs, OperatorBase, AOs> o(o_ij);
+            REQUIRE(o.bra() == bra);
+            REQUIRE(o.op().are_equal(op));
+            REQUIRE(o.ket() == ket);
+        }
         SECTION("copy") {
             BraKet copy_o(o_ij);
             REQUIRE(copy_o == o_ij);


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This PR enables implicit conversions from a type like `BraKet<AOs, T_e, AOs>` to a type like `BraKet<AOs, OperatorBase, AOs>` where the template parameters of one type are implicitly convertible to template parameters of the other type.

**TODOs**
None. R2g.
