### PR TITLE
all BraKet objects are now tensors

### DIFF
--- a/include/chemist/quantum_mechanics/braket/braket_class.hpp
+++ b/include/chemist/quantum_mechanics/braket/braket_class.hpp
@@ -153,7 +153,7 @@ public:
      *                        throw guarantee.
      */
     BraKet(const BraKet& other) :
-      BraKet(other.bra(), other.op(), other.ket()) {};
+      BraKet(other.bra(), other.op(), other.ket()){};
 
     /** @brief Initializes *this by taking the state from @p other.
      *

--- a/include/chemist/quantum_mechanics/braket/braket_class.hpp
+++ b/include/chemist/quantum_mechanics/braket/braket_class.hpp
@@ -38,7 +38,7 @@ namespace detail_ {
 template<typename BraType, typename OperatorType, typename KetType>
 using bra_ket_base_type =
   std::conditional_t<is_tensor_element_v<BraType, OperatorType, KetType>,
-                     TensorElement<double>, TensorRepresentation>;
+                     TensorRepresentation, TensorRepresentation>;
 
 } // namespace detail_
 
@@ -153,7 +153,7 @@ public:
      *                        throw guarantee.
      */
     BraKet(const BraKet& other) :
-      BraKet(other.bra(), other.op(), other.ket()){};
+      BraKet(other.bra(), other.op(), other.ket()) {};
 
     /** @brief Initializes *this by taking the state from @p other.
      *


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This tweaks the BraKet class so it always inherits from `TensorRepresentation`. This works for now, but in the long term, we need to think about if there's a reason to keep `TensorElement` around.

**TODOs**
None. R2g.
