### PR TITLE
FragmentedNuclei works with NucleiView

### DIFF
--- a/include/chemist/fragmenting/fragmented_nuclei.hpp
+++ b/include/chemist/fragmenting/fragmented_nuclei.hpp
@@ -121,6 +121,19 @@ public:
      */
     explicit FragmentedNuclei(supersystem_type supersystem);
 
+    /** @brief Creates an empty object.
+     *
+     *  This ctor works the same as the other ctor for creating an empty object,
+     *  except that it takes a view of the supersystem. See the description for
+     *  the by-value overload for more details.
+     *
+     *  @param[in] supersystem The object *this will hold fragments of.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating memory. Strong
+     *                        throw guarantee.
+     */
+    explicit FragmentedNuclei(const_supersystem_reference supersystem);
+
     /** @brief Initializes *this with the provided set of fragments.
      *
      *  @param[in] supersystem The object that is being fragmented.
@@ -133,6 +146,24 @@ public:
      *                        state. Strong throw guarantee.
      */
     FragmentedNuclei(supersystem_type supersystem, nucleus_map_type frags);
+
+    /** @brief Initializes *this with the provided set of fragments.
+     *
+     *  This overload dispatches to previous overload after copying
+     *  @p supersystem. See the description for the other overload for more
+     *  details.
+     *
+     *  @param[in] supersystem The object that is being fragmented.
+     *  @param[in] frags A container-of-containers object such that
+     *                   `frags[i][j]` is the offset (with respect to
+     *                   @p supersystem) of the `j`-th nucleus in the `i`-th
+     *                   fragment.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the initial
+     *                        state. Strong throw guarantee.
+     */
+    FragmentedNuclei(const_supersystem_reference supersystem,
+                     nucleus_map_type frags);
 
     /** @brief Initializes *this from fragments and a set of caps.
      *
@@ -148,6 +179,25 @@ public:
      */
     FragmentedNuclei(supersystem_type supersystem, nucleus_map_type frags,
                      cap_set_type caps);
+
+    /** @brief Initializes *this from fragments and a set of caps.
+     *
+     *  This overload dispatches to previous overload after copying
+     *  @p supersystem. See the description for the other overload for more
+     *  details.
+     *
+     *  @param[in] supersystem The object being fragmented.
+     *  @param[in] frags A container-of-containers object such that
+     *                   `frags[i][j]` is the offset (with respect to
+     *                   @p supersystem) of the `j`-th nucleus in the `i`-th
+     *                   fragment.
+     *  @param[in] caps The caps for fixing severed bonds.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the initial
+     *                        state. Strong throw guarantee.
+     */
+    FragmentedNuclei(const_supersystem_reference supersystem,
+                     nucleus_map_type frags, cap_set_type caps);
 
     /** @brief Initializes *this to a copy of @p other.
      *

--- a/src/chemist/fragmenting/fragmented_nuclei.cpp
+++ b/src/chemist/fragmenting/fragmented_nuclei.cpp
@@ -121,15 +121,30 @@ FRAGMENTED_NUCLEI::FragmentedNuclei(supersystem_type supersystem) :
   FragmentedNuclei(std::move(supersystem), nucleus_map_type{}) {}
 
 TPARAMS
+FRAGMENTED_NUCLEI::FragmentedNuclei(const_supersystem_reference supersystem) :
+  FragmentedNuclei(supersystem.as_nuclei()) {}
+
+TPARAMS
 FRAGMENTED_NUCLEI::FragmentedNuclei(supersystem_type supersystem,
                                     nucleus_map_type frags) :
   FragmentedNuclei(std::move(supersystem), std::move(frags), cap_set_type{}) {}
+
+TPARAMS
+FRAGMENTED_NUCLEI::FragmentedNuclei(const_supersystem_reference supersystem,
+                                    nucleus_map_type frags) :
+  FragmentedNuclei(supersystem.as_nuclei(), std::move(frags)) {}
 
 TPARAMS
 FRAGMENTED_NUCLEI::FragmentedNuclei(supersystem_type supersystem,
                                     nucleus_map_type frags, cap_set_type caps) :
   m_pimpl_(std::make_unique<pimpl_type>(std::move(supersystem),
                                         std::move(frags), std::move(caps))) {}
+
+TPARAMS
+FRAGMENTED_NUCLEI::FragmentedNuclei(const_supersystem_reference supersystem,
+                                    nucleus_map_type frags, cap_set_type caps) :
+  FragmentedNuclei(supersystem.as_nuclei(), std::move(frags), std::move(caps)) {
+}
 
 TPARAMS
 FRAGMENTED_NUCLEI::FragmentedNuclei(const FragmentedNuclei& other) :

--- a/tests/cxx/unit_tests/fragmenting/fragmented_nuclei.cpp
+++ b/tests/cxx/unit_tests/fragmenting/fragmented_nuclei.cpp
@@ -29,6 +29,10 @@ TEMPLATE_LIST_TEST_CASE("FragmentedNuclei", "", types2test) {
     // Non-cv qualified supersystem type
     using supersystem_type = typename set_type::supersystem_type;
 
+    // Type of a read-only reference to the supersystem
+    using const_supersystem_reference =
+      typename set_type::const_supersystem_reference;
+
     // Type of a reference to a fragment
     using fragment_reference = typename set_type::reference;
 
@@ -52,6 +56,7 @@ TEMPLATE_LIST_TEST_CASE("FragmentedNuclei", "", types2test) {
     nucleus_type h2("H", 1ul, 1.0, 8.0, 9.0, 0.0);
 
     supersystem_type ss{h0, h1, h2};
+    const_supersystem_reference ss_ref(ss);
     index_set_type i0{0}, i1{1}, i2{2}, i01{0, 1}, i12{1, 2};
 
     fragment_map_type disjoint;
@@ -113,6 +118,12 @@ TEMPLATE_LIST_TEST_CASE("FragmentedNuclei", "", types2test) {
             REQUIRE(no_frags.supersystem() == ss);
         }
 
+        SECTION("Empty (reference)") {
+            set_type no_frags_ref(ss_ref);
+            REQUIRE(no_frags_ref.size() == 0);
+            REQUIRE(no_frags_ref.supersystem() == ss);
+        }
+
         SECTION("Frags, but no caps") {
             REQUIRE(disjoint_no_caps.size() == 3);
             REQUIRE(disjoint_no_caps[0] == corr0);
@@ -124,6 +135,19 @@ TEMPLATE_LIST_TEST_CASE("FragmentedNuclei", "", types2test) {
             REQUIRE(nondisjoint_no_caps[1] == corr12);
         }
 
+        SECTION("Frags, but no caps (reference)") {
+            set_type disjoint_no_caps_ref(ss_ref, disjoint);
+            REQUIRE(disjoint_no_caps_ref.size() == 3);
+            REQUIRE(disjoint_no_caps_ref[0] == corr0);
+            REQUIRE(disjoint_no_caps_ref[1] == corr1);
+            REQUIRE(disjoint_no_caps_ref[2] == corr2);
+
+            set_type nondisjoint_no_caps_ref(ss_ref, nondisjoint);
+            REQUIRE(nondisjoint_no_caps_ref.size() == 2);
+            REQUIRE(nondisjoint_no_caps_ref[0] == corr01);
+            REQUIRE(nondisjoint_no_caps_ref[1] == corr12);
+        }
+
         SECTION("Frags with caps") {
             REQUIRE(disjoint_caps.size() == 3);
             REQUIRE(disjoint_caps[0] == corr0_cap);
@@ -133,6 +157,19 @@ TEMPLATE_LIST_TEST_CASE("FragmentedNuclei", "", types2test) {
             REQUIRE(nondisjoint_caps.size() == 2);
             REQUIRE(nondisjoint_caps[0] == corr01);
             REQUIRE(nondisjoint_caps[1] == corr12_cap);
+        }
+
+        SECTION("Frags with caps (reference)") {
+            set_type disjoint_caps_ref(ss_ref, disjoint, caps);
+            REQUIRE(disjoint_caps_ref.size() == 3);
+            REQUIRE(disjoint_caps_ref[0] == corr0_cap);
+            REQUIRE(disjoint_caps_ref[1] == corr1_cap);
+            REQUIRE(disjoint_caps_ref[2] == corr2);
+
+            set_type nondisjoint_caps_ref(ss_ref, nondisjoint, caps);
+            REQUIRE(nondisjoint_caps_ref.size() == 2);
+            REQUIRE(nondisjoint_caps_ref[0] == corr01);
+            REQUIRE(nondisjoint_caps_ref[1] == corr12_cap);
         }
 
         SECTION("copy") {


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
I added overloads so we don't have to call `.as_nuclei()` downstream.

**TODOs**
None. R2g.
