### PR TITLE
adds missing overload

### DIFF
--- a/include/chemist/point_charge/charges_view.hpp
+++ b/include/chemist/point_charge/charges_view.hpp
@@ -124,6 +124,20 @@ public:
      */
     ChargesView(charges_reference charges);
 
+    /** @brief Creates a ChargesView that aliases @p points and @p pq.
+     *
+     *  This ctor is used to alias a PointSet that is aliasing its points and a
+     *  a set of contiguous charges.
+     *
+     *  @param[in] points A view of the points.
+     *  @param[in] pq A pointer such that `*(pq + i)` is the charge for
+     *                `points[i]`.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the state. Strong
+     *                        throw guarantee.
+     */
+    ChargesView(point_set_reference points, charge_pointer pq);
+
     /** @brief Creates a new alias to the Charges object aliased by @p other.
      *
      *  This ctor is a shallow copy of the aliased Charges object and a deep

--- a/src/chemist/point_charge/charges_view.cpp
+++ b/src/chemist/point_charge/charges_view.cpp
@@ -31,8 +31,12 @@ CHARGES_VIEW::ChargesView() noexcept = default;
 
 TPARAMS
 CHARGES_VIEW::ChargesView(charges_reference charges) :
+  ChargesView(charges.point_set(), charges.charge_data()) {}
+
+TPARAMS
+CHARGES_VIEW::ChargesView(point_set_reference points, charge_pointer pcharges) :
   m_pimpl_(std::make_unique<detail_::ChargesContiguous<ChargesType>>(
-    charges.point_set(), charges.charge_data())) {}
+    points, pcharges)) {}
 
 TPARAMS
 CHARGES_VIEW::ChargesView(const ChargesView& other) :

--- a/tests/cxx/unit_tests/point_charge/charges_view.cpp
+++ b/tests/cxx/unit_tests/point_charge/charges_view.cpp
@@ -53,6 +53,15 @@ void test_charges_view_guts() {
             REQUIRE(charges[2] == q2);
         }
 
+        SECTION("points and charges") {
+            view_type ps_and_qs(charges_qs.point_set(),
+                                charges_qs.charge_data());
+            REQUIRE(ps_and_qs.size() == 3);
+            REQUIRE(ps_and_qs[0] == q0);
+            REQUIRE(ps_and_qs[1] == q1);
+            REQUIRE(ps_and_qs[2] == q2);
+        }
+
         SECTION("Copy") {
             view_type defaulted_copy(defaulted);
             REQUIRE(defaulted == defaulted_copy);


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
`ChargesView` was missing the constructor that allows it to be constructed from a `PointSetView` and a `double *` (former for the coordinates and the latter for the charges). This PR adds that ctor.

**TODOs**
None. R2g.
