### PR TITLE
Starts work to evaluate AOs on grid

### DIFF
--- a/include/chemist/basis_set/contracted_gaussian.hpp
+++ b/include/chemist/basis_set/contracted_gaussian.hpp
@@ -83,8 +83,13 @@ public:
     /// Type resulting from evaluating *this at a point
     using numerical_value = typename primitive_traits::coord_type;
 
+    /// Type resulting from evaluating *this at a set of points
+    using numerical_vector = std::vector<numerical_value>;
+
+    /// Type of a read-only view of a point
     using const_point_view = typename primitive_traits::const_center_reference;
 
+    /// Type of a read-only view of a set of points
     using const_point_set_view =
       typename primitive_traits::const_point_set_view;
 
@@ -277,7 +282,7 @@ public:
      *
      *  @return The value of the contracted Gaussian at the requested points.
      */
-    std::vector<numerical_value> evaluate(const_point_set_view points) const;
+    numerical_vector evaluate(const_point_set_view points) const;
 
     // -------------------------------------------------------------------------
     // -- Utility functions

--- a/include/chemist/basis_set/contracted_gaussian.hpp
+++ b/include/chemist/basis_set/contracted_gaussian.hpp
@@ -80,6 +80,14 @@ public:
     /// Unsigned integral type of an index/offset
     using size_type = typename container_base::size_type;
 
+    /// Type resulting from evaluating *this at a point
+    using numerical_value = typename primitive_traits::coord_type;
+
+    using const_point_view = typename primitive_traits::const_center_reference;
+
+    using const_point_set_view =
+      typename primitive_traits::const_point_set_view;
+
     /** @brief Makes a null ContractedGaussian.
      *
      *  The default ctor makes a null ContractedGaussian instance which means
@@ -245,6 +253,31 @@ public:
      *  @throw std::runtime_error if *this is null. Strong throw guarantee.
      */
     typename primitive_traits::const_center_reference center() const;
+
+    /** @brief Computes the value of *this at the point @p r.
+     *
+     *  The value of a contracted Gaussian at the vector @f$r@f$ is the sum of
+     *  the primitive gaussians forming the contraction evaluated at @f$r@f$.
+     *
+     *  @param[in] r The point where the contracted Gaussian should be
+     *             evaluated.
+     *
+     *  @return The value of the contracted Gaussian at the point @p r.
+     */
+    numerical_value evaluate(const_point_view r) const;
+
+    /** @brief Computes the value of *this at a series of points @p points.
+     *
+     *  This function is the same as the other overload of evaluate except that
+     *  it computes the value of the contracted Gaussian at a series of points
+     *  and returns a vector of the values.
+     *
+     *  @param[in] points The points where the contracted Gaussian should be
+     *                    evaluated.
+     *
+     *  @return The value of the contracted Gaussian at the requested points.
+     */
+    std::vector<numerical_value> evaluate(const_point_set_view points) const;
 
     // -------------------------------------------------------------------------
     // -- Utility functions

--- a/include/chemist/basis_set/contracted_gaussian_view.hpp
+++ b/include/chemist/basis_set/contracted_gaussian_view.hpp
@@ -114,6 +114,10 @@ public:
     /// Type used to represent the value of *this at a point
     using numerical_value = typename contracted_gaussian_type::numerical_value;
 
+    /// Type used to represent the value of *this at a set of points
+    using numerical_vector =
+      typename contracted_gaussian_type::numerical_vector;
+
     /// Type used to represent a view of a point
     using const_point_view =
       typename contracted_gaussian_type::const_point_view;
@@ -339,7 +343,7 @@ public:
      *
      *  @return The value of the contracted Gaussian at the requested points.
      */
-    std::vector<numerical_value> evaluate(const_point_set_view points) const;
+    numerical_vector evaluate(const_point_set_view points) const;
 
     // -------------------------------------------------------------------------
     // -- Utility functions

--- a/include/chemist/basis_set/contracted_gaussian_view.hpp
+++ b/include/chemist/basis_set/contracted_gaussian_view.hpp
@@ -111,6 +111,17 @@ public:
     /// Unsigned integral type used for indexing and offsets
     using size_type = typename base_type::size_type;
 
+    /// Type used to represent the value of *this at a point
+    using numerical_value = typename contracted_gaussian_type::numerical_value;
+
+    /// Type used to represent a view of a point
+    using const_point_view =
+      typename contracted_gaussian_type::const_point_view;
+
+    /// Type used to represent constant view of a set of points
+    using const_point_set_view =
+      typename contracted_gaussian_type::const_point_set_view;
+
 private:
     /// Type of the traits giving *this the Primitive types
     using primitive_traits = PrimitiveTraits<reference>;
@@ -304,6 +315,31 @@ public:
      *                            throw guarantee.
      */
     typename primitive_traits::const_center_reference center() const;
+
+    /** @brief Computes the value of *this at the point @p r.
+     *
+     *  The value of a contracted Gaussian at the vector @f$r@f$ is the sum of
+     *  the primitive gaussians forming the contraction evaluated at @f$r@f$.
+     *
+     *  @param[in] r The point where the contracted Gaussian should be
+     *             evaluated.
+     *
+     *  @return The value of the contracted Gaussian at the point @p r.
+     */
+    numerical_value evaluate(const_point_view r) const;
+
+    /** @brief Computes the value of *this at a series of points @p points.
+     *
+     *  This function is the same as the other overload of evaluate except that
+     *  it computes the value of the contracted Gaussian at a series of points
+     *  and returns a vector of the values.
+     *
+     *  @param[in] points The points where the contracted Gaussian should be
+     *                    evaluated.
+     *
+     *  @return The value of the contracted Gaussian at the requested points.
+     */
+    std::vector<numerical_value> evaluate(const_point_set_view points) const;
 
     // -------------------------------------------------------------------------
     // -- Utility functions

--- a/include/chemist/basis_set/primitive.hpp
+++ b/include/chemist/basis_set/primitive.hpp
@@ -18,6 +18,7 @@
 #include <chemist/point/point.hpp>
 #include <chemist/point/point_view.hpp>
 #include <memory>
+#include <vector>
 
 namespace chemist::basis_set {
 namespace detail_ {
@@ -104,6 +105,15 @@ public:
 
     /// Type of a pointer to a read-only exponent
     using const_exponent_pointer = const exponent_type*;
+
+    /// Type resulting from evaluating the primitive at a point
+    using numerical_value = T;
+
+    /// Type resulting from evaluating the primitive at a set of points
+    using numerical_vector = std::vector<numerical_value>;
+
+    /// Type of a read-only view of a point
+    using const_point_view = PointView<const center_type>;
 
     /// Type of a read-only view of a set of points
     using const_point_set_view = PointSetView<const PointSet<T>>;
@@ -320,7 +330,7 @@ public:
      *  @throw std::runtime_error if *this is in a null state. Strong throw
      *         guarantee.
      */
-    T evaluate(const_center_reference r) const;
+    numerical_value evaluate(const_point_view r) const;
 
     /** @brief Computes the value of the current primitive at a series of
      *         points.
@@ -338,7 +348,7 @@ public:
      *         std::bad_alloc if there is insufficient memory to allocate the
      *         return. Strong throw guarantee.
      */
-    std::vector<T> evaluate(const_point_set_view points) const;
+    numerical_vector evaluate(const_point_set_view points) const;
 
     // -------------------------------------------------------------------------
     // -- Utility Functions

--- a/include/chemist/basis_set/primitive.hpp
+++ b/include/chemist/basis_set/primitive.hpp
@@ -303,8 +303,41 @@ public:
      */
     const_exponent_reference exponent() const;
 
+    /** @brief Computes the value of the current primitive at the point @p r.
+     *
+     *  The value of a Gaussian primitive at the vector @f$r@f$ is given by:
+     *  @f[
+     *    g(\vec{r}) = c e^{-\alpha \left(\vec{r}-\vec{r_0}\right)^2},
+     *  @f]
+     *
+     *  where @f$c@f$ is the coefficient, @f$\alpha@f$ is the exponent, and
+     *  @f$\vec{r_0}@f$ is the point where the primitive is centered.
+     *
+     *  @param[in] r The point where the primitive should be evaluated.
+     *
+     *  @return The value of the primitive at the point @p r.
+     *
+     *  @throw std::runtime_error if *this is in a null state. Strong throw
+     *         guarantee.
+     */
     T evaluate(const_center_reference r) const;
 
+    /** @brief Computes the value of the current primitive at a series of
+     *         points.
+     *
+     *  This function is the same as the other overload of evaluate except that
+     *  it computes the value of the primitive at a series of points and returns
+     *  a vector of the values.
+     *
+     *  @param[in] points The points where the primitive should be evaluated.
+     *
+     *  @return The value of the primitive at the requested points.
+     *
+     *  @throw std::runtime_error if *this is in a null state. Strong throw
+     *         guarantee.
+     *         std::bad_alloc if there is insufficient memory to allocate the
+     *         return. Strong throw guarantee.
+     */
     std::vector<T> evaluate(const_point_set_view points) const;
 
     // -------------------------------------------------------------------------

--- a/include/chemist/basis_set/primitive.hpp
+++ b/include/chemist/basis_set/primitive.hpp
@@ -105,6 +105,9 @@ public:
     /// Type of a pointer to a read-only exponent
     using const_exponent_pointer = const exponent_type*;
 
+    /// Type of a read-only view of a set of points
+    using const_point_set_view = PointSetView<const PointSet<T>>;
+
     // -------------------------------------------------------------------------
     // -- Ctors, assignment, and dtor
     // -------------------------------------------------------------------------
@@ -299,6 +302,10 @@ public:
      *         guarantee.
      */
     const_exponent_reference exponent() const;
+
+    T evaluate(const_center_reference r) const;
+
+    std::vector<T> evaluate(const_point_set_view points) const;
 
     // -------------------------------------------------------------------------
     // -- Utility Functions

--- a/include/chemist/basis_set/primitive_traits.hpp
+++ b/include/chemist/basis_set/primitive_traits.hpp
@@ -72,6 +72,9 @@ struct PrimitiveTraits {
 
     /// Type of a reference to a read-only coordinate
     using const_coord_reference = typename PrimitiveType::const_coord_reference;
+
+    /// Type of a read-only view of a set of points
+    using const_point_set_view = typename PrimitiveType::const_point_set_view;
 };
 
 } // namespace chemist::basis_set

--- a/include/chemist/basis_set/primitive_view.hpp
+++ b/include/chemist/basis_set/primitive_view.hpp
@@ -138,6 +138,16 @@ public:
     using const_exponent_pointer =
       typename primitive_type::const_exponent_pointer;
 
+    /// Type resulting from evaluating the primitive at a point
+    using numerical_value = typename primitive_type::numerical_value;
+
+    /// Type resulting from evaluating the primitive at a set of points
+    using numerical_vector = typename primitive_type::numerical_vector;
+
+    /// Type of a read-only view of a point
+    using const_point_view = typename primitive_type::const_center_reference;
+
+    /// Type of a read-only view of a set of points
     using const_point_set_view = typename primitive_type::const_point_set_view;
 
     // -------------------------------------------------------------------------
@@ -343,7 +353,7 @@ public:
      *  @throw std::runtime_error if *this is in a null state. Strong throw
      *         guarantee.
      */
-    coord_type evaluate(const_center_reference r) const;
+    numerical_value evaluate(const_point_view r) const;
 
     /** @brief Computes the value of the current primitive at a series of
      *         points.
@@ -361,7 +371,7 @@ public:
      *         std::bad_alloc if there is insufficient memory to allocate the
      *         return. Strong throw guarantee.
      */
-    std::vector<coord_type> evaluate(const_point_set_view points) const;
+    numerical_vector evaluate(const_point_set_view points) const;
 
     // -------------------------------------------------------------------------
     // -- Utility functions

--- a/include/chemist/basis_set/primitive_view.hpp
+++ b/include/chemist/basis_set/primitive_view.hpp
@@ -138,6 +138,8 @@ public:
     using const_exponent_pointer =
       typename primitive_type::const_exponent_pointer;
 
+    using const_point_set_view = typename primitive_type::const_point_set_view;
+
     // -------------------------------------------------------------------------
     // -- Ctors, assignment, and dtor
     // -------------------------------------------------------------------------
@@ -323,6 +325,43 @@ public:
      *                            Strong throw guarantee.
      */
     const_exponent_reference exponent() const;
+
+    /** @brief Computes the value of the current primitive at the point @p r.
+     *
+     *  The value of a Gaussian primitive at the vector @f$r@f$ is given by:
+     *  @f[
+     *    g(\vec{r}) = c e^{-\alpha \left(\vec{r}-\vec{r_0}\right)^2},
+     *  @f]
+     *
+     *  where @f$c@f$ is the coefficient, @f$\alpha@f$ is the exponent, and
+     *  @f$\vec{r_0}@f$ is the point where the primitive is centered.
+     *
+     *  @param[in] r The point where the primitive should be evaluated.
+     *
+     *  @return The value of the primitive at the point @p r.
+     *
+     *  @throw std::runtime_error if *this is in a null state. Strong throw
+     *         guarantee.
+     */
+    coord_type evaluate(const_center_reference r) const;
+
+    /** @brief Computes the value of the current primitive at a series of
+     *         points.
+     *
+     *  This function is the same as the other overload of evaluate except that
+     *  it computes the value of the primitive at a series of points and returns
+     *  a vector of the values.
+     *
+     *  @param[in] points The points where the primitive should be evaluated.
+     *
+     *  @return The value of the primitive at the requested points.
+     *
+     *  @throw std::runtime_error if *this is in a null state. Strong throw
+     *         guarantee.
+     *         std::bad_alloc if there is insufficient memory to allocate the
+     *         return. Strong throw guarantee.
+     */
+    std::vector<coord_type> evaluate(const_point_set_view points) const;
 
     // -------------------------------------------------------------------------
     // -- Utility functions

--- a/include/chemist/point/point_class.hpp
+++ b/include/chemist/point/point_class.hpp
@@ -269,7 +269,28 @@ public:
      *  @throw None No throw guarantee.
      */
     coord_type magnitude() const noexcept {
-        return std::sqrt(x() * x() + y() * y() + z() * z());
+        return std::sqrt(inner_product(*this));
+    }
+
+    /** @brief Returns the inner product of *this with @p rhs.
+     *
+     * The inner product of two points is defined as:
+     *
+     * @f[
+     *  \vec{a} \cdot \vec{b} = a_x b_x + a_y b_y + a_z b_z
+     * @f]
+     *
+     * and is the scalar projection of point @f$\vec{a}@f$ onto the
+     * point @f$\vec{b}@f$.
+     *
+     * @param[in] rhs The Point to take the inner product with.
+     *
+     * @return The inner product of *this with @p rhs.
+     *
+     * @throw None No throw guarantee.
+     */
+    coord_type inner_product(const Point<T>& rhs) const noexcept {
+        return x() * rhs.x() + y() * rhs.y() + z() * rhs.z();
     }
 
     /** @brief Serialize Point instance

--- a/include/chemist/point/point_view.hpp
+++ b/include/chemist/point/point_view.hpp
@@ -313,10 +313,10 @@ private:
 };
 
 /// Computes the vector difference of between two aliased Points
-template<typename T>
-Point<T> operator-(PointView<const Point<T>> lhs,
-                   PointView<const Point<T>> rhs) noexcept {
-    return Point<T>(lhs.x() - rhs.x(), lhs.y() - rhs.y(), lhs.z() - rhs.z());
+template<typename LHSType, typename RHSType>
+auto operator-(PointView<LHSType> lhs, PointView<RHSType> rhs) noexcept {
+    using point_type = std::decay_t<LHSType>;
+    return point_type(lhs.x() - rhs.x(), lhs.y() - rhs.y(), lhs.z() - rhs.z());
 }
 
 /// Same as PointView::operator==, but when a Point is the LHS

--- a/include/chemist/point/point_view.hpp
+++ b/include/chemist/point/point_view.hpp
@@ -197,8 +197,33 @@ public:
     const_coord_reference z() const noexcept { return coord(2); }
     ///@}
 
+    /** @brief Returns the magnitude of the point
+     *
+     *  This function returns the magnitude of the current point, *i.e.*, the
+     *  distance from the origin.
+     *
+     *  @return The magnitude of the current point.
+     *
+     *  @throw None No throw guarantee.
+     */
     coord_type magnitude() const noexcept {
-        return std::sqrt(x() * x() + y() * y() + z() * z());
+        return std::sqrt(inner_product(*this));
+    }
+
+    /** @brief Returns the inner product of *this with @p rhs.
+     *
+     *  This method returns the inner product of the Point aliased by *this
+     *  with the Point aliased by @p rhs.
+     *
+     *  @param[in] rhs The Point-like object we are taking the inner product
+     *                 with.
+     *
+     *  @return The inner product of the Point aliased by *this with @p rhs.
+     *
+     *  @throw None No throw guarantee.
+     */
+    coord_type inner_product(const_point_view rhs) const noexcept {
+        return x() * rhs.x() + y() * rhs.y() + z() * rhs.z();
     }
 
     /** @brief Value comparison.
@@ -286,6 +311,13 @@ private:
     /// Pointers to the x, y, and z coordinates (respectively)
     std::array<internal_pointer, 3> m_pr_;
 };
+
+/// Computes the vector difference of between two aliased Points
+template<typename T>
+Point<T> operator-(PointView<const Point<T>> lhs,
+                   PointView<const Point<T>> rhs) noexcept {
+    return Point<T>(lhs.x() - rhs.x(), lhs.y() - rhs.y(), lhs.z() - rhs.z());
+}
 
 /// Same as PointView::operator==, but when a Point is the LHS
 template<typename CoordType, typename PointType>

--- a/src/chemist/basis_set/contracted_gaussian.cpp
+++ b/src/chemist/basis_set/contracted_gaussian.cpp
@@ -71,8 +71,7 @@ typename CG::numerical_value CG::evaluate(const_point_view r) const {
 }
 
 template<typename PrimitiveType>
-std::vector<typename CG::numerical_value> CG::evaluate(
-  const_point_set_view points) const {
+typename CG::numerical_vector CG::evaluate(const_point_set_view points) const {
     std::vector<numerical_value> results(points.size(), 0.0);
     for(const auto& prim : *this) {
         auto prim_results = prim.evaluate(points);

--- a/src/chemist/basis_set/contracted_gaussian.cpp
+++ b/src/chemist/basis_set/contracted_gaussian.cpp
@@ -63,6 +63,26 @@ typename CG::primitive_traits::const_center_reference CG::center() const {
     return m_pimpl_->center();
 }
 
+template<typename PrimitiveType>
+typename CG::numerical_value CG::evaluate(const_point_view r) const {
+    numerical_value rv = 0.0;
+    for(const auto& prim : *this) { rv += prim.evaluate(r); }
+    return rv;
+}
+
+template<typename PrimitiveType>
+std::vector<typename CG::numerical_value> CG::evaluate(
+  const_point_set_view points) const {
+    std::vector<numerical_value> results(points.size(), 0.0);
+    for(const auto& prim : *this) {
+        auto prim_results = prim.evaluate(points);
+        for(std::size_t i = 0; i < points.size(); ++i) {
+            results[i] += prim_results[i];
+        }
+    }
+    return results;
+}
+
 // -----------------------------------------------------------------------------
 // -- Utility functions
 // -----------------------------------------------------------------------------

--- a/src/chemist/basis_set/contracted_gaussian_view.cpp
+++ b/src/chemist/basis_set/contracted_gaussian_view.cpp
@@ -82,6 +82,26 @@ typename CG_VIEW::primitive_traits::const_center_reference CG_VIEW::center()
     return m_pimpl_->center();
 }
 
+template<typename CGType>
+typename CG_VIEW::numerical_value CG_VIEW::evaluate(const_point_view r) const {
+    numerical_value rv = 0.0;
+    for(const auto& prim : *this) { rv += prim.evaluate(r); }
+    return rv;
+}
+
+template<typename CGType>
+std::vector<typename CG_VIEW::numerical_value> CG_VIEW::evaluate(
+  const_point_set_view points) const {
+    std::vector<numerical_value> results(points.size(), 0.0);
+    for(const auto& prim : *this) {
+        auto prim_results = prim.evaluate(points);
+        for(std::size_t i = 0; i < points.size(); ++i) {
+            results[i] += prim_results[i];
+        }
+    }
+    return results;
+}
+
 // -----------------------------------------------------------------------------
 // -- Utility functions
 // -----------------------------------------------------------------------------

--- a/src/chemist/basis_set/contracted_gaussian_view.cpp
+++ b/src/chemist/basis_set/contracted_gaussian_view.cpp
@@ -90,7 +90,7 @@ typename CG_VIEW::numerical_value CG_VIEW::evaluate(const_point_view r) const {
 }
 
 template<typename CGType>
-std::vector<typename CG_VIEW::numerical_value> CG_VIEW::evaluate(
+typename CG_VIEW::numerical_vector CG_VIEW::evaluate(
   const_point_set_view points) const {
     std::vector<numerical_value> results(points.size(), 0.0);
     for(const auto& prim : *this) {

--- a/src/chemist/basis_set/primitive.cpp
+++ b/src/chemist/basis_set/primitive.cpp
@@ -101,14 +101,16 @@ typename PRIM_TYPE::const_exponent_reference PRIM_TYPE::exponent() const {
 }
 
 template<typename T>
-T PRIM_TYPE::evaluate(const_center_reference r) const {
+typename PRIM_TYPE::numerical_value PRIM_TYPE::evaluate(
+  const_point_view r) const {
     auto dr  = r - const_center_reference(center());
     auto dr2 = dr.inner_product(dr);
     return coefficient() * std::exp(-exponent() * dr2);
 }
 
 template<typename T>
-std::vector<T> PRIM_TYPE::evaluate(const_point_set_view points) const {
+typename PRIM_TYPE::numerical_vector PRIM_TYPE::evaluate(
+  const_point_set_view points) const {
     std::vector<T> results;
     results.reserve(points.size());
     for(std::size_t i = 0; i < points.size(); ++i) {

--- a/src/chemist/basis_set/primitive.cpp
+++ b/src/chemist/basis_set/primitive.cpp
@@ -100,6 +100,23 @@ typename PRIM_TYPE::const_exponent_reference PRIM_TYPE::exponent() const {
     return m_pimpl_->m_exponent;
 }
 
+template<typename T>
+T PRIM_TYPE::evaluate(const_center_reference r) const {
+    auto dr  = r - const_center_reference(center());
+    auto dr2 = dr.inner_product(dr);
+    return coefficient() * std::exp(-exponent() * dr2);
+}
+
+template<typename T>
+std::vector<T> PRIM_TYPE::evaluate(const_point_set_view points) const {
+    std::vector<T> results;
+    results.reserve(points.size());
+    for(std::size_t i = 0; i < points.size(); ++i) {
+        results.push_back(evaluate(points[i]));
+    }
+    return results;
+}
+
 // -----------------------------------------------------------------------------
 // -- Utility Functions
 // -----------------------------------------------------------------------------

--- a/src/chemist/basis_set/primitive_view.cpp
+++ b/src/chemist/basis_set/primitive_view.cpp
@@ -74,6 +74,25 @@ typename PRIMITIVE_VIEW::const_exponent_reference PRIMITIVE_VIEW::exponent()
     return *m_exp_;
 }
 
+PRIMITIVE_TPARAMS
+typename PRIMITIVE_VIEW::coord_type PRIMITIVE_VIEW::evaluate(
+  const_center_reference r) const {
+    auto dr  = r - const_center_reference(center());
+    auto dr2 = dr.inner_product(dr);
+    return coefficient() * std::exp(-exponent() * dr2);
+}
+
+PRIMITIVE_TPARAMS
+std::vector<typename PRIMITIVE_VIEW::coord_type> PRIMITIVE_VIEW::evaluate(
+  const_point_set_view points) const {
+    std::vector<coord_type> results;
+    results.reserve(points.size());
+    for(std::size_t i = 0; i < points.size(); ++i) {
+        results.push_back(evaluate(points[i]));
+    }
+    return results;
+}
+
 // -----------------------------------------------------------------------------
 // -- Utility functions
 // -----------------------------------------------------------------------------

--- a/src/chemist/basis_set/primitive_view.cpp
+++ b/src/chemist/basis_set/primitive_view.cpp
@@ -75,15 +75,15 @@ typename PRIMITIVE_VIEW::const_exponent_reference PRIMITIVE_VIEW::exponent()
 }
 
 PRIMITIVE_TPARAMS
-typename PRIMITIVE_VIEW::coord_type PRIMITIVE_VIEW::evaluate(
-  const_center_reference r) const {
+typename PRIMITIVE_VIEW::numerical_value PRIMITIVE_VIEW::evaluate(
+  const_point_view r) const {
     auto dr  = r - const_center_reference(center());
     auto dr2 = dr.inner_product(dr);
     return coefficient() * std::exp(-exponent() * dr2);
 }
 
 PRIMITIVE_TPARAMS
-std::vector<typename PRIMITIVE_VIEW::coord_type> PRIMITIVE_VIEW::evaluate(
+typename PRIMITIVE_VIEW::numerical_vector PRIMITIVE_VIEW::evaluate(
   const_point_set_view points) const {
     std::vector<coord_type> results;
     results.reserve(points.size());

--- a/tests/cxx/unit_tests/basis_set/contracted_gaussian.cpp
+++ b/tests/cxx/unit_tests/basis_set/contracted_gaussian.cpp
@@ -182,6 +182,32 @@ TEMPLATE_TEST_CASE("ContractedGaussian", "", float, double) {
         }
     }
 
+    SECTION("evaluate(point)") {
+        center_type origin;
+
+        REQUIRE(cg0.evaluate(r0) == 0.0);
+        REQUIRE(cg0.evaluate(origin) == 0.0);
+        REQUIRE(cg1.evaluate(r0) == Catch::Approx(6.0).epsilon(1e-6));
+
+        auto corr = 6.0 * std::exp(-2046.0);
+        REQUIRE(cg1.evaluate(origin) == Catch::Approx(corr).epsilon(1e-6));
+    }
+
+    SECTION("evaluate(PointSet)") {
+        center_type origin;
+        chemist::PointSet<TestType> pts{origin, r0};
+        using const_point_set_view = typename cg_type::const_point_set_view;
+        auto rv                    = cg1.evaluate(const_point_set_view(pts));
+        REQUIRE(rv.size() == 2);
+        REQUIRE(rv[0] == Catch::Approx(6.0 * std::exp(-2046.0)).epsilon(1e-6));
+        REQUIRE(rv[1] == Catch::Approx(6.0).epsilon(1e-6));
+
+        rv = cg0.evaluate(const_point_set_view(pts));
+        REQUIRE(rv.size() == 2);
+        REQUIRE(rv[0] == 0.0);
+        REQUIRE(rv[1] == 0.0);
+    }
+
     SECTION("utility") {
         SECTION("swap") {
             cg_type cg0_copy(cg0);

--- a/tests/cxx/unit_tests/basis_set/contracted_gaussian_view.cpp
+++ b/tests/cxx/unit_tests/basis_set/contracted_gaussian_view.cpp
@@ -322,6 +322,32 @@ TEMPLATE_TEST_CASE("ContractedGaussianView", "", float, double) {
         }
     }
 
+    SECTION("evaluate(point)") {
+        center_type origin;
+
+        REQUIRE(cg0_view.evaluate(r0) == 0.0);
+        REQUIRE(cg0_view.evaluate(origin) == 0.0);
+        REQUIRE(cg1_view.evaluate(r0) == Catch::Approx(6.0).epsilon(1e-6));
+
+        auto corr = 6.0 * std::exp(-2046.0);
+        REQUIRE(cg1_view.evaluate(origin) == Catch::Approx(corr).epsilon(1e-6));
+    }
+
+    SECTION("evaluate(PointSet)") {
+        center_type origin;
+        chemist::PointSet<TestType> pts{origin, r0};
+        using const_point_set_view = typename cg_type::const_point_set_view;
+        auto rv = cg1_view.evaluate(const_point_set_view(pts));
+        REQUIRE(rv.size() == 2);
+        REQUIRE(rv[0] == Catch::Approx(6.0 * std::exp(-2046.0)).epsilon(1e-6));
+        REQUIRE(rv[1] == Catch::Approx(6.0).epsilon(1e-6));
+
+        rv = cg0_view.evaluate(const_point_set_view(pts));
+        REQUIRE(rv.size() == 2);
+        REQUIRE(rv[0] == 0.0);
+        REQUIRE(rv[1] == 0.0);
+    }
+
     SECTION("utility") {
         SECTION("swap") {
             view_type cg0_copy(cg0_view);

--- a/tests/cxx/unit_tests/basis_set/primitive.cpp
+++ b/tests/cxx/unit_tests/basis_set/primitive.cpp
@@ -174,6 +174,23 @@ TEMPLATE_TEST_CASE("Primitive", "", float, double) {
         REQUIRE(std::as_const(values).exponent() == 5.0);
     }
 
+    SECTION("evaluate(point)") {
+        REQUIRE_THROWS_AS(defaulted.evaluate(origin) == 0.0,
+                          std::runtime_error);
+        REQUIRE(values.evaluate(origin) ==
+                Catch::Approx(4.0 * std::exp(-70.0)).epsilon(1e-6));
+
+        REQUIRE(values.evaluate(r0) == Catch::Approx(4.0).epsilon(1e-6));
+    }
+
+    SECTION("evalutate(PointSet)") {
+        chemist::PointSet<TestType> pts{origin, r0};
+        using const_point_set_view = typename prim_type::const_point_set_view;
+        auto rv                    = values.evaluate(const_point_set_view(pts));
+        REQUIRE(rv[0] == Catch::Approx(4.0 * std::exp(-70.0)).epsilon(1e-6));
+        REQUIRE(rv[1] == Catch::Approx(4.0).epsilon(1e-6));
+    }
+
     SECTION("is_null") {
         REQUIRE(defaulted.is_null());
 

--- a/tests/cxx/unit_tests/basis_set/primitive_view.cpp
+++ b/tests/cxx/unit_tests/basis_set/primitive_view.cpp
@@ -38,6 +38,7 @@ TEMPLATE_TEST_CASE("PrimitiveView", "", float, double) {
     using view_type   = PrimitiveView<prim_type>;
     using const_view  = PrimitiveView<const prim_type>;
 
+    center_type origin;
     center_type r0(1.0, 2.0, 3.0);
     prim_type defaulted;
     prim_type values(4.0, 5.0, r0);
@@ -302,6 +303,23 @@ TEMPLATE_TEST_CASE("PrimitiveView", "", float, double) {
             REQUIRE(std::as_const(values_view).exponent() == 5.0);
             REQUIRE(std::as_const(const_values_view).exponent() == 5.0);
         }
+    }
+
+    SECTION("evaluate(point)") {
+        REQUIRE_THROWS_AS(defaulted_view.evaluate(origin) == 0.0,
+                          std::runtime_error);
+        REQUIRE(values_view.evaluate(origin) ==
+                Catch::Approx(4.0 * std::exp(-70.0)).epsilon(1e-6));
+
+        REQUIRE(values.evaluate(r0) == Catch::Approx(4.0).epsilon(1e-6));
+    }
+
+    SECTION("evalutate(PointSet)") {
+        chemist::PointSet<TestType> pts{origin, r0};
+        using const_point_set_view = typename prim_type::const_point_set_view;
+        auto rv = values_view.evaluate(const_point_set_view(pts));
+        REQUIRE(rv[0] == Catch::Approx(4.0 * std::exp(-70.0)).epsilon(1e-6));
+        REQUIRE(rv[1] == Catch::Approx(4.0).epsilon(1e-6));
     }
 
     SECTION("utility functions") {

--- a/tests/cxx/unit_tests/point/point.cpp
+++ b/tests/cxx/unit_tests/point/point.cpp
@@ -216,6 +216,13 @@ TEST_CASE("Point<double> : magnitude") {
     REQUIRE(p0.magnitude() == Catch::Approx(corr));
 }
 
+TEST_CASE("Point<double> : inner_product") {
+    Point<double> p0{1.0, 2.0, 3.0};
+    Point<double> p1(4.0, 5.0, 6.0);
+    double corr = 32.0;
+    REQUIRE(p0.inner_product(p1) == Catch::Approx(corr));
+}
+
 TEST_CASE("operator<<(ostream, Point)") {
     SECTION("float") {
         Point<float> p0{1.023456789, 9.102345678, 8.910234567};

--- a/tests/cxx/unit_tests/point/point_view.cpp
+++ b/tests/cxx/unit_tests/point/point_view.cpp
@@ -182,10 +182,14 @@ TEMPLATE_TEST_CASE("PointView", "", Point<double>, Point<float>) {
     }
 
     SECTION("operator-") {
-        // REQUIRE((r1 - r0) == (pr1 - pr0));
-        // REQUIRE((r0 - r1) == (pr0 - pr1));
-        // REQUIRE((r0 - r0) == (pr0 - pr0));
-        // REQUIRE((r1 - r1) == (pr1 - pr1));
+        TestType r1(3.0, 4.0, 5.0);
+        TestType r01(-3.0, -3.0, -3.0);
+        TestType r10(3.0, 3.0, 3.0);
+        TestType r00(0.0, 0.0, 0.0);
+        REQUIRE((pr1 - pr0) == r10);
+        REQUIRE((pr0 - pr1) == r01);
+        REQUIRE((pr0 - pr0) == r00);
+        REQUIRE((pr1 - pr1) == r00);
     }
 
     SECTION("Comparisons") {

--- a/tests/cxx/unit_tests/point/point_view.cpp
+++ b/tests/cxx/unit_tests/point/point_view.cpp
@@ -175,6 +175,19 @@ TEMPLATE_TEST_CASE("PointView", "", Point<double>, Point<float>) {
         REQUIRE(pr1.magnitude() == r1.magnitude());
     }
 
+    SECTION("inner_product") {
+        REQUIRE(pr0.inner_product(r0) == r0.inner_product(r0));
+        REQUIRE(pr1.inner_product(r1) == r1.inner_product(r1));
+        REQUIRE(pr0.inner_product(r1) == r0.inner_product(r1));
+    }
+
+    SECTION("operator-") {
+        // REQUIRE((r1 - r0) == (pr1 - pr0));
+        // REQUIRE((r0 - r1) == (pr0 - pr1));
+        // REQUIRE((r0 - r0) == (pr0 - pr0));
+        // REQUIRE((r1 - r1) == (pr1 - pr1));
+    }
+
     SECTION("Comparisons") {
         // N.B. We test the symmetry of the operator to ensure the view works
         //      seamlessly with Point


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Will partially resolve NWChemEx/SCF#34

**Description**
This PR will make it so we can do:

```
AOBasisSet aos = get_basis();
Grid grid = get_grid();
Tensor ao2grid = aos.evaluate(grid.points());
```

Update: I'm going to stop at contracted Gaussian. Going forward is really facilitated by having an `AO`, `CartesianAO`, and `SphericalAO` classes, instead of skipping from `ContractedGaussian` to `Shell` like we currently do. In our first pass of DFT the uncertainty is going to be in the density so we can use gau2grid for building the collocation matrix for now.

**TODOs**
None for now.