### PR TITLE
Python XC Functionals Enum

### DIFF
--- a/src/python/module.cpp
+++ b/src/python/module.cpp
@@ -29,13 +29,15 @@
 namespace chemist {
 
 void export_chemist_enums(python_module_reference m) {
-    python_enum_type<ShellType>(m, "ShellType")
+    python_enum_type<ShellType>(m, "ShellType", "enum.Enum")
       .value("cartesian", ShellType::cartesian)
-      .value("pure", ShellType::pure);
+      .value("pure", ShellType::pure)
+      .finalize();
 
-    python_enum_type<GaugeType>(m, "GaugeType")
+    python_enum_type<GaugeType>(m, "GaugeType", "enum.Enum")
       .value("length", GaugeType::length)
-      .value("velocity", GaugeType::velocity);
+      .value("velocity", GaugeType::velocity)
+      .finalize();
 }
 
 PYBIND11_MODULE(chemist, m) {

--- a/src/python/pychemist.hpp
+++ b/src/python/pychemist.hpp
@@ -15,6 +15,7 @@
  */
 
 #pragma once
+#include <pybind11/native_enum.h>
 #include <pybind11/pybind11.h>
 
 namespace chemist {
@@ -27,7 +28,7 @@ template<typename... Args>
 using python_class_type = pybind11::class_<Args...>;
 
 template<typename... Args>
-using python_enum_type = pybind11::enum_<Args...>;
+using python_enum_type = pybind11::native_enum<Args...>;
 
 /** @brief Convenience function for checking if a pybind11 object can be
  *         cast to  type T

--- a/src/python/quantum_mechanics/operator/export_exchange_correlation.cpp
+++ b/src/python/quantum_mechanics/operator/export_exchange_correlation.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "export_operator.hpp"
+#include <chemist/quantum_mechanics/operator/exchange_correlation.hpp>
+#include <pybind11/native_enum.h>
+
+namespace chemist::qm_operator {
+
+void export_xc_functionals(python_module_reference m) {
+    python_enum_type<xc_functional>(m, "xc_functional", "enum.Enum")
+      .value("NONE", xc_functional::NONE)
+      .value("CUSTOM", xc_functional::CUSTOM)
+      .value("SVWN3", xc_functional::SVWN3)
+      .value("SVWN5", xc_functional::SVWN5)
+      .value("BLYP", xc_functional::BLYP)
+      .value("B3LYP", xc_functional::B3LYP)
+      .value("PBE", xc_functional::PBE)
+      .value("revPBE", xc_functional::revPBE)
+      .value("PBE0", xc_functional::PBE0)
+      .finalize();
+}
+
+} // namespace chemist::qm_operator

--- a/src/python/quantum_mechanics/operator/export_operator.hpp
+++ b/src/python/quantum_mechanics/operator/export_operator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 NWChemEx-Project
+ * Copyright 2025 NWChemEx-Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,16 @@
  */
 
 #pragma once
-#include "operator/export_operator.hpp"
-#include "wavefunction/export_wavefunction.hpp"
+#include "../../pychemist.hpp"
 
-namespace chemist {
+namespace chemist::qm_operator {
 
-inline void export_quantum_mechanics(python_module_reference m) {
-    qm_operator::export_qm_operator(m);
-    wavefunction::export_wavefunction(m);
+void export_xc_functionals(python_module_reference m);
+
+inline void export_qm_operator(python_module_reference m) {
+    auto m_op = m.def_submodule("qm_operator");
+
+    export_xc_functionals(m_op);
 }
 
-} // namespace chemist
+} // namespace chemist::qm_operator

--- a/tests/cxx/unit_tests/grid/grid_class.cpp
+++ b/tests/cxx/unit_tests/grid/grid_class.cpp
@@ -16,6 +16,7 @@
 
 #include "../test_helpers.hpp"
 #include <chemist/grid/grid_class.hpp>
+#include <utility>
 
 using namespace chemist;
 

--- a/tests/cxx/unit_tests/grid/grid_point.cpp
+++ b/tests/cxx/unit_tests/grid/grid_point.cpp
@@ -16,6 +16,7 @@
 
 #include "../test_helpers.hpp"
 #include <chemist/grid/grid_point.hpp>
+#include <utility>
 
 using namespace chemist;
 using point_type = GridPoint::point_type;

--- a/tests/cxx/unit_tests/grid/grid_point_view.cpp
+++ b/tests/cxx/unit_tests/grid/grid_point_view.cpp
@@ -16,6 +16,7 @@
 
 #include "../test_helpers.hpp"
 #include <chemist/grid/grid_point_view.hpp>
+#include <utility>
 
 using namespace chemist;
 using point_type = GridPoint::point_type;


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
The main point of these changes is to add Python bindings for the `xc_functional` enum to make DFT calculations in Python feasible. Along with this addition, I've also taken the opportunity to update the `python_enum_type` typedef from the deprecated `pybind11::enum_` to the preferred `pybind11::native_enum`, which required some minor updates to the bindings of pre-existing enums. Finally, I ran into a couple of tests that need `#include <utility>` added to them.