### PR TITLE
Python Bindings for Density classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,13 +99,13 @@ if("${BUILD_TESTING}")
     nwx_pybind11_tests(
         py_chemist
         "${PYTHON_TEST_DIR}/unit_tests/test_chemist.py"
-        SUBMODULES parallelzone
+        SUBMODULES tensorwrapper parallelzone
     )
 
     nwx_pybind11_tests(
         py_${PROJECT_NAME}_docs
         "${PYTHON_TEST_DIR}/doc_snippets/test_doc_snippets.py"
-        SUBMODULES parallelzone
+        SUBMODULES tensorwrapper parallelzone
     )
 endif()
 

--- a/include/chemist/density/density_class.hpp
+++ b/include/chemist/density/density_class.hpp
@@ -74,6 +74,15 @@ public:
     Density(value_type rho, basis_type orbs) :
       m_density_(std::move(rho)), m_orbs_(std::move(orbs)) {}
 
+    /** @brief Standard defaulted dtor
+     *
+     *  This dtor will free up the memory associated with the PIMPL. As a
+     *  result, all references to the Point's coordinates will be invalidated.
+     *
+     *  @throw none No throw guarantee.
+     */
+    virtual ~Density() noexcept = default;
+
     /** @brief Returns a mutable reference to the density matrix.
      *
      *  @return A mutable reference to the tensor representation of the density.

--- a/src/python/density/export_decomposable_density.cpp
+++ b/src/python/density/export_decomposable_density.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "export_density.hpp"
+#include <chemist/density/decomposable_density.hpp>
+#include <pybind11/operators.h>
+
+namespace chemist {
+
+void export_decomposable_density(python_module_reference m) {
+    using decomposable_density_t = DecomposableDensity<Electron>;
+    using density_t              = Density<Electron>;
+    using basis_t                = typename density_t::basis_type;
+    using value_t                = typename decomposable_density_t::value_type;
+    using transformed_basis_t =
+      typename decomposable_density_t::transformed_basis_type;
+
+    python_class_type<decomposable_density_t, density_t>(m,
+                                                         "DecomposableDensity")
+      .def(pybind11::init<>())
+      .def(pybind11::init<value_t, transformed_basis_t>())
+      .def(pybind11::init<value_t, basis_t, value_t>())
+      .def_property_readonly(
+        "left_factor",
+        [](decomposable_density_t& d) { return d.left_factor(); })
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self != pybind11::self);
+}
+
+} // namespace chemist

--- a/src/python/density/export_density.hpp
+++ b/src/python/density/export_density.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "../pychemist.hpp"
+
+namespace chemist {
+
+void export_density_class(python_module_reference m);
+// void export_decomposable_density(python_module_reference m);
+
+inline void export_density(python_module_reference m) {
+    export_density_class(m);
+    // export_decomposable_density(m);
+}
+
+} // namespace chemist

--- a/src/python/density/export_density.hpp
+++ b/src/python/density/export_density.hpp
@@ -20,11 +20,11 @@
 namespace chemist {
 
 void export_density_class(python_module_reference m);
-// void export_decomposable_density(python_module_reference m);
+void export_decomposable_density(python_module_reference m);
 
 inline void export_density(python_module_reference m) {
     export_density_class(m);
-    // export_decomposable_density(m);
+    export_decomposable_density(m);
 }
 
 } // namespace chemist

--- a/src/python/density/export_density_class.cpp
+++ b/src/python/density/export_density_class.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "export_density.hpp"
+#include <chemist/density/density_class.hpp>
+#include <pybind11/operators.h>
+
+namespace chemist {
+
+void export_density_class(python_module_reference m) {
+    using density_t = Density<Electron>;
+    using basis_t   = typename density_t::basis_type;
+    using value_t   = typename density_t::value_type;
+
+    // Property getters and setters
+    auto get_value = [](density_t& d) { return d.value(); };
+    auto set_value = [](density_t& d, value_t& v) { d.value() = v; };
+    auto get_basis = [](density_t& d) { return d.basis_set(); };
+    auto set_basis = [](density_t& d, basis_t& bs) { d.basis_set() = bs; };
+
+    // Ensure that tensorwrapper is imported
+    python_module_type::import("tensorwrapper");
+
+    python_class_type<density_t>(m, "Density")
+      .def(pybind11::init<>())
+      .def(pybind11::init<value_t, basis_t>())
+      .def_property("value", get_value, set_value)
+      .def_property("basis_set", get_basis, set_basis)
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self != pybind11::self);
+}
+
+} // namespace chemist

--- a/src/python/module.cpp
+++ b/src/python/module.cpp
@@ -16,6 +16,7 @@
 
 #include "basis_set/export_basis_set.hpp"
 #include "chemical_system/export_chemical_system.hpp"
+#include "density/export_density.hpp"
 #include "electron/export_electron.hpp"
 #include "enums.hpp"
 #include "fragmenting/export_fragmenting.hpp"
@@ -56,6 +57,8 @@ PYBIND11_MODULE(chemist, m) {
     export_chemist_enums(m);
     export_basis_set(m);
     export_quantum_mechanics(m);
+
+    export_density(m);
 
     export_grid(m);
 

--- a/src/python/quantum_mechanics/wavefunction/export_tranformed.cpp
+++ b/src/python/quantum_mechanics/wavefunction/export_tranformed.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "export_wavefunction.hpp"
+#include <chemist/quantum_mechanics/wavefunction/wavefunction.hpp>
+#include <pybind11/operators.h>
+
+namespace chemist::wavefunction {
+namespace detail_ {
+
+template<typename T>
+void export_transformed_(const char* name, python_module_reference m) {
+    using transformed_t = Transformed<T>;
+    using from_space_t  = typename transformed_t::from_space_type;
+    using transform_t   = typename transformed_t::transform_type;
+
+    // Property getters and setters
+    auto get_from_space = [](transformed_t& t) { return t.from_space(); };
+    auto set_from_space = [](transformed_t& t, from_space_t& s) {
+        t.from_space() = s;
+    };
+    auto get_transform = [](transformed_t& t) { return t.transform(); };
+    auto set_transform = [](transformed_t& t, transform_t& c) {
+        t.transform() = c;
+    };
+
+    // Ensure that tensorwrapper is imported
+    python_module_type::import("tensorwrapper");
+
+    python_class_type<transformed_t, VectorSpace>(m, name)
+      .def(pybind11::init<>())
+      .def(pybind11::init<from_space_t, transform_t>())
+      .def_property("from_space", get_from_space, set_from_space)
+      .def_property("transform", get_transform, set_transform)
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self != pybind11::self);
+}
+} // namespace detail_
+
+void export_transformed(python_module_reference m) {
+    detail_::export_transformed_<AOs>("TransformedAOs", m);
+}
+
+} // namespace chemist::wavefunction

--- a/src/python/quantum_mechanics/wavefunction/export_wavefunction.hpp
+++ b/src/python/quantum_mechanics/wavefunction/export_wavefunction.hpp
@@ -21,12 +21,14 @@ namespace chemist::wavefunction {
 
 void export_vector_space(python_module_reference m);
 void export_aos(python_module_reference m);
+void export_transformed(python_module_reference m);
 
 inline void export_wavefunction(python_module_reference m) {
     auto m_wf = m.def_submodule("wavefunction");
 
     export_vector_space(m_wf);
     export_aos(m_wf);
+    export_transformed(m_wf);
 }
 
 } // namespace chemist::wavefunction

--- a/tests/python/unit_tests/density/__init__.py
+++ b/tests/python/unit_tests/density/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/python/unit_tests/density/test_decomposable_density.py
+++ b/tests/python/unit_tests/density/test_decomposable_density.py
@@ -1,0 +1,60 @@
+# Copyright 2026 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from chemist.wavefunction import AOs, TransformedAOs
+from tensorwrapper import Tensor
+
+from chemist import DecomposableDensity
+
+from .test_density import h2_basis
+
+
+class TestDensityClass(unittest.TestCase):
+    def test_default_ctor(self):
+        self.assertEqual(self.defaulted.basis_set.size(), 0)
+        self.assertEqual(self.defaulted.value, Tensor())
+        self.assertEqual(self.defaulted.left_factor, Tensor())
+
+    def test_value_ctor(self):
+        self.assertEqual(self.has_value1.value, self.value)
+        self.assertEqual(self.has_value1.basis_set, self.aos)
+        self.assertEqual(self.has_value1.left_factor, self.value)
+
+        self.assertEqual(self.has_value2.value, self.value)
+        self.assertEqual(self.has_value2.basis_set, self.aos)
+        self.assertEqual(self.has_value2.left_factor, self.value)
+
+    def test_left_factor(self):
+        # Basic access tested in ctor tests
+        # This is read-only, so let's just check that attempting to write raises
+        with self.assertRaises(AttributeError):
+            self.defaulted.left_factor = self.value
+
+    def test_comparisons(self):
+        self.assertEqual(self.defaulted, DecomposableDensity())
+        self.assertNotEqual(self.defaulted, self.has_value1)
+        self.assertEqual(self.has_value1, self.has_value2)
+
+    def setUp(self):
+        self.defaulted = DecomposableDensity()
+        self.np_value = np.array([[1.0, 2.0], [3.0, 4.0]])
+        self.value = Tensor(self.np_value)
+        self.basis = h2_basis()
+        self.aos = AOs(self.basis)
+        self.transformed_aos = TransformedAOs(self.aos, self.value)
+        self.has_value1 = DecomposableDensity(self.value, self.transformed_aos)
+        self.has_value2 = DecomposableDensity(self.value, self.aos, self.value)

--- a/tests/python/unit_tests/density/test_density.py
+++ b/tests/python/unit_tests/density/test_density.py
@@ -1,0 +1,43 @@
+# Copyright 2024 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from chemist import PointD, ShellType
+from chemist.basis_set import AOBasisSetD, AtomicBasisSetD, ContractedGaussianD
+
+
+def h2_coords():
+    return [0.0, 0.0, 0.0, 0.0, 0.0, 1.3983972315]
+
+
+def h2_basis():
+    coords = h2_coords()
+    h0_coords = PointD(coords[0], coords[1], coords[2])
+    h1_coords = PointD(coords[3], coords[4], coords[5])
+
+    coefs = [0.1543289673, 0.5353281423, 0.4446345422]
+    exps = [3.425250914, 0.6239137298, 0.1688554040]
+    h0_cg = ContractedGaussianD(coefs, exps, h0_coords)
+    h1_cg = ContractedGaussianD(coefs, exps, h1_coords)
+
+    cartesian = ShellType.cartesian
+    h0 = AtomicBasisSetD("STO-3G", 1, h0_coords)
+    h0.add_shell(cartesian, 0, h0_cg)
+    h1 = AtomicBasisSetD("STO-3G", 1, h1_coords)
+    h1.add_shell(cartesian, 0, h1_cg)
+
+    rv = AOBasisSetD()
+    rv.add_center(h0)
+    rv.add_center(h1)
+
+    return rv

--- a/tests/python/unit_tests/density/test_density_class.py
+++ b/tests/python/unit_tests/density/test_density_class.py
@@ -1,0 +1,58 @@
+# Copyright 2026 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+from chemist.wavefunction import AOs
+from tensorwrapper import Tensor
+
+from chemist import Density
+
+from .test_density import h2_basis
+
+
+class TestDensityClass(unittest.TestCase):
+    def test_default_ctor(self):
+        self.assertEqual(self.defaulted.basis_set.size(), 0)
+        self.assertEqual(self.defaulted.value, Tensor())
+
+    def test_value_ctor(self):
+        self.assertEqual(self.has_value.value, self.value)
+        self.assertEqual(self.has_value.basis_set, self.aos)
+
+    def test_value(self):
+        # Basic access tested int ctor tests
+        # Now we need to test if we can write to it
+        self.defaulted.value = self.value
+        self.assertEqual(self.defaulted.value, self.value)
+
+    def test_basis_set(self):
+        # Basic access tested in ctor tests
+        # Now we need to test if we can write to it
+        self.defaulted.basis_set = self.aos
+        self.assertEqual(self.defaulted.basis_set, self.aos)
+
+    def test_equality(self):
+        self.assertEqual(self.defaulted, Density())
+        self.assertNotEqual(self.defaulted, self.has_value)
+        self.assertEqual(self.has_value, Density(self.value, self.aos))
+
+    def setUp(self):
+        self.defaulted = Density()
+        self.np_value = np.array([[1.0, 2.0], [3.0, 4.0]])
+        self.value = Tensor(self.np_value)
+        self.basis = h2_basis()
+        self.aos = AOs(self.basis)
+        self.has_value = Density(self.value, self.aos)

--- a/tests/python/unit_tests/quantum_mechanics/wavefunction/test_transformed.py
+++ b/tests/python/unit_tests/quantum_mechanics/wavefunction/test_transformed.py
@@ -15,44 +15,48 @@
 import unittest
 
 import numpy as np
-from chemist.wavefunction import AOs
+from chemist.wavefunction import AOs, TransformedAOs
 from tensorwrapper import Tensor
 
-from chemist import Density
+from chemist.basis_set import AOBasisSetD
 
-from .test_density import h2_basis
+from ..test_qm import h2_basis
 
 
-class TestDensityClass(unittest.TestCase):
+class TestAOs(unittest.TestCase):
     def test_default_ctor(self):
-        self.assertEqual(self.defaulted.basis_set.size(), 0)
-        self.assertEqual(self.defaulted.value, Tensor())
+        self.assertEqual(self.defaulted.from_space.size(), 0)
+        self.assertEqual(self.defaulted.from_space.ao_basis_set, AOBasisSetD())
+        self.assertEqual(self.defaulted.transform, Tensor())
 
     def test_value_ctor(self):
-        self.assertEqual(self.has_value.value, self.value)
-        self.assertEqual(self.has_value.basis_set, self.aos)
+        self.assertEqual(self.has_value.from_space, self.aos)
+        self.assertEqual(self.has_value.transform, self.transform)
 
-    def test_value(self):
+    def test_from_space(self):
         # Basic access tested in ctor tests
         # Now we need to test if we can write to it
-        self.defaulted.value = self.value
-        self.assertEqual(self.defaulted.value, self.value)
+        self.defaulted.from_space = self.aos
+        self.assertEqual(self.defaulted.from_space, self.aos)
 
-    def test_basis_set(self):
+    def test_transform(self):
         # Basic access tested in ctor tests
         # Now we need to test if we can write to it
-        self.defaulted.basis_set = self.aos
-        self.assertEqual(self.defaulted.basis_set, self.aos)
+        self.defaulted.transform = self.transform
+        self.assertEqual(self.defaulted.transform, self.transform)
 
     def test_comparisons(self):
-        self.assertEqual(self.defaulted, Density())
+        self.assertEqual(self.defaulted, TransformedAOs())
         self.assertNotEqual(self.defaulted, self.has_value)
-        self.assertEqual(self.has_value, Density(self.value, self.aos))
+        self.assertEqual(
+            self.has_value, TransformedAOs(self.aos, self.transform)
+        )
 
     def setUp(self):
-        self.defaulted = Density()
+        self.defaulted = TransformedAOs()
+        self.empty_aos = AOs()
         self.np_value = np.array([[1.0, 2.0], [3.0, 4.0]])
-        self.value = Tensor(self.np_value)
+        self.transform = Tensor(self.np_value)
         self.basis = h2_basis()
         self.aos = AOs(self.basis)
-        self.has_value = Density(self.value, self.aos)
+        self.has_value = TransformedAOs(self.aos, self.transform)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Adds python bindings for the `Density`, `DecomposableDensity`, and `TransformedAOs` (`Transformed<AOs>`) classes.