### PR TITLE
Operators in Python

### DIFF
--- a/include/chemist/quantum_mechanics/operator/coulomb.hpp
+++ b/include/chemist/quantum_mechanics/operator/coulomb.hpp
@@ -56,58 +56,44 @@ public:
     /// Defaulted, nothrow dtor
     ~Coulomb() noexcept = default;
 
-    /** @brief Returns the lhs particle
-     *
-     *  The Coulomb energy is a two particle operator. We term the first
-     *  particle the lhs particle (short for left hand side). This method can be
-     *  used to retrieve the lhs particle.
-     *
-     *  This is a convenience function for calling the base class's at member.
-     *
-     *  @return A mutable reference to the lhs particle.
-     *
-     *  @throw None No throw guarantee.
-     */
-    lhs_reference lhs_particle() { return base_type::template at<0>(); }
-
     /** @brief Returns a read-only reference to the lhs particle.
-     *
-     *  This method is the same as the non-const version except that the result
-     *  is read-only.
      *
      *  @return A read-only reference to the lhs particle.
      *
      *  @throw None No throw guarantee.
      */
-    const_lhs_reference lhs_particle() const {
-        return base_type::template at<0>();
+    const_lhs_reference get_lhs_particle() const {
+        return base_type::template get<0>();
     }
 
-    /** @brief Returns the rhs particle
+    /** @brief Update the value of the lhs particle
      *
-     *  The Coulomb energy is a two particle operator. We term the second
-     *  particle the rhs particle (short for right hand side). This method can
-     *  be used to retrieve the rhs particle.
-     *
-     *  This is a convenience function for calling the base class's at member.
-     *
-     *  @return A mutable reference to the rhs particle.
+     *  @param[in] p The new value of the lhs particle.
      *
      *  @throw None No throw guarantee.
      */
-    rhs_reference rhs_particle() { return base_type::template at<1>(); }
+    void set_lhs_particle(lhs_value_type p) {
+        base_type::template set<0>(std::move(p));
+    }
 
     /** @brief Returns a read-only reference to the rhs particle.
-     *
-     *  This method is the same as the non-const version except that the result
-     *  is read-only.
      *
      *  @return A read-only reference to the rhs particle.
      *
      *  @throw None No throw guarantee.
      */
-    const_rhs_reference rhs_particle() const {
-        return base_type::template at<1>();
+    const_rhs_reference get_rhs_particle() const {
+        return base_type::template get<1>();
+    }
+
+    /** @brief Update the value of the rhs particle
+     *
+     *  @param[in] p The new value of the rhs particle.
+     *
+     *  @throw None No throw guarantee.
+     */
+    void set_rhs_particle(rhs_value_type p) {
+        base_type::template set<1>(std::move(p));
     }
 };
 

--- a/include/chemist/quantum_mechanics/operator/detail_/operator_impl.hpp
+++ b/include/chemist/quantum_mechanics/operator/detail_/operator_impl.hpp
@@ -115,8 +115,8 @@ public:
 
     /** @brief Returns the @p i-th particle in *this.
      *
-     *  This method returns a mutable reference to the @p i-th particle involved
-     *  in this operator.
+     *  This method returns a read-only reference to the @p i-th particle
+     *  involved in this operator.
      *
      *  @tparam i The offset of the particle. @p i should be in the range 0 to
      *          sizeof...(Particles).
@@ -124,24 +124,25 @@ public:
      *  @throw None No throw guarantee.
      */
     template<std::size_t i>
-    particle_reference<i> at() {
+    const_particle_reference<i> get() const {
         return std::get<i>(m_particles_);
     }
 
-    /** @brief REturns the @p i-th particle in *this.
+    /** @brief Updates the value of the @p i-th particle in *this.
      *
-     *  This method is the same as the non-const version except that the
-     *  resulting particle is read-only. See the documentation for the non-const
-     *  version for more details.
+     *  This method updates the value of the @p i-th particle involved in this
+     *  operator.
      *
      *  @tparam i The offset of the particle. @p i should be in the range 0 to
      *          sizeof...(Particles).
      *
+     *  @param[in] p The new value of the @p i-th particle.
+     *
      *  @throw None No throw guarantee.
      */
     template<std::size_t i>
-    const_particle_reference<i> at() const {
-        return std::get<i>(m_particles_);
+    void set(particle_type<i> p) {
+        std::get<i>(m_particles_) = std::move(p);
     }
 
     /** @brief Non-polymorphically determines if *this is value equal to @p rhs.

--- a/include/chemist/quantum_mechanics/operator/exchange.hpp
+++ b/include/chemist/quantum_mechanics/operator/exchange.hpp
@@ -57,58 +57,44 @@ public:
     /// Defaulted, nothrow dtor
     ~Exchange() noexcept = default;
 
-    /** @brief Returns the lhs particle
-     *
-     *  The Exchange energy is a two particle operator. We term the first
-     *  particle the lhs particle (short for left hand side). This method can be
-     *  used to retrieve the lhs particle.
-     *
-     *  This is a convenience function for calling the base class's at member.
-     *
-     *  @return A mutable reference to the lhs particle.
-     *
-     *  @throw None No throw guarantee.
-     */
-    lhs_reference lhs_particle() { return base_type::template at<0>(); }
-
     /** @brief Returns a read-only reference to the lhs particle.
-     *
-     *  This method is the same as the non-const version except that the result
-     *  is read-only.
      *
      *  @return A read-only reference to the lhs particle.
      *
      *  @throw None No throw guarantee.
      */
-    const_lhs_reference lhs_particle() const {
-        return base_type::template at<0>();
+    const_lhs_reference get_lhs_particle() const {
+        return base_type::template get<0>();
     }
 
-    /** @brief Returns the rhs particle
+    /** @brief Update the value of the lhs particle
      *
-     *  The Exchange energy is a two particle operator. We term the second
-     *  particle the rhs particle (short for right hand side). This method can
-     *  be used to retrieve the rhs particle.
-     *
-     *  This is a convenience function for calling the base class's at member.
-     *
-     *  @return A mutable reference to the rhs particle.
+     *  @param[in] p The new value of the lhs particle.
      *
      *  @throw None No throw guarantee.
      */
-    rhs_reference rhs_particle() { return base_type::template at<1>(); }
+    void set_lhs_particle(lhs_value_type p) {
+        base_type::template set<0>(std::move(p));
+    }
 
     /** @brief Returns a read-only reference to the rhs particle.
-     *
-     *  This method is the same as the non-const version except that the result
-     *  is read-only.
      *
      *  @return A read-only reference to the rhs particle.
      *
      *  @throw None No throw guarantee.
      */
-    const_rhs_reference rhs_particle() const {
-        return base_type::template at<1>();
+    const_rhs_reference get_rhs_particle() const {
+        return base_type::template get<1>();
+    }
+
+    /** @brief Update the value of the rhs particle
+     *
+     *  @param[in] p The new value of the rhs particle.
+     *
+     *  @throw None No throw guarantee.
+     */
+    void set_rhs_particle(rhs_value_type p) {
+        base_type::template set<1>(std::move(p));
     }
 };
 

--- a/include/chemist/quantum_mechanics/operator/exchange_correlation.hpp
+++ b/include/chemist/quantum_mechanics/operator/exchange_correlation.hpp
@@ -102,79 +102,63 @@ public:
     /// Defaulted, nothrow dtor
     ~ExchangeCorrelation() noexcept = default;
 
-    /** @brief Returns the lhs particle
-     *
-     *  The ExchangeCorrelation energy is a two particle operator. We term the
-     * first particle the lhs particle (short for left hand side). This method
-     * can be used to retrieve the lhs particle.
-     *
-     *  This is a convenience function for calling the base class's at member.
-     *
-     *  @return A mutable reference to the lhs particle.
-     *
-     *  @throw None No throw guarantee.
-     */
-    lhs_reference lhs_particle() { return base_type::template at<0>(); }
-
     /** @brief Returns a read-only reference to the lhs particle.
-     *
-     *  This method is the same as the non-const version except that the result
-     *  is read-only.
      *
      *  @return A read-only reference to the lhs particle.
      *
      *  @throw None No throw guarantee.
      */
-    const_lhs_reference lhs_particle() const {
-        return base_type::template at<0>();
+    const_lhs_reference get_lhs_particle() const {
+        return base_type::template get<0>();
     }
 
-    /** @brief Returns the rhs particle
+    /** @brief Update the value of the lhs particle
      *
-     *  The ExchangeCorrelation energy is a two particle operator. We term the
-     * second particle the rhs particle (short for right hand side). This method
-     * can be used to retrieve the rhs particle.
-     *
-     *  This is a convenience function for calling the base class's at member.
-     *
-     *  @return A mutable reference to the rhs particle.
+     *  @param[in] p The new value of the lhs particle.
      *
      *  @throw None No throw guarantee.
      */
-    rhs_reference rhs_particle() { return base_type::template at<1>(); }
+    void set_lhs_particle(lhs_value_type p) {
+        base_type::template set<0>(std::move(p));
+    }
 
     /** @brief Returns a read-only reference to the rhs particle.
-     *
-     *  This method is the same as the non-const version except that the result
-     *  is read-only.
      *
      *  @return A read-only reference to the rhs particle.
      *
      *  @throw None No throw guarantee.
      */
-    const_rhs_reference rhs_particle() const {
-        return base_type::template at<1>();
+    const_rhs_reference get_rhs_particle() const {
+        return base_type::template get<1>();
     }
 
-    /** @brief The name of the XC functional.
+    /** @brief Update the value of the rhs particle
      *
-     *  This will be something like PBE or BLYP.
-     *
-     *  @return A mutable reference to the name of the XC functional.
+     *  @param[in] p The new value of the rhs particle.
      *
      *  @throw None No throw guarantee.
      */
-    auto& functional_name() noexcept { return m_xc_form_; }
+    void set_rhs_particle(rhs_value_type p) {
+        base_type::template set<1>(std::move(p));
+    }
 
     /** @brief The name of the XC functional.
-     *
-     *  Same as the non-const version, except the result is read-only.
      *
      *  @return The name of the XC functional.
      *
      *  @throw None No throw guarantee.
      */
-    auto functional_name() const noexcept { return m_xc_form_; }
+    auto get_functional_name() const noexcept { return m_xc_form_; }
+
+    /** @brief Update the name of the XC functional.
+     *
+     *  @param[in] func_name The new name of the XC functional.
+     *
+     *  @throw None No throw guarantee.
+     */
+    void set_functional_name(functional_type func_name) noexcept {
+        m_xc_form_ = func_name;
+    }
 
 private:
     /// The name of the XC functional's form.

--- a/include/chemist/quantum_mechanics/operator/kinetic.hpp
+++ b/include/chemist/quantum_mechanics/operator/kinetic.hpp
@@ -70,30 +70,25 @@ public:
     /// Defaulted, nothrow dtor
     ~Kinetic() noexcept = default;
 
-    /** @brief Returns the particle
-     *
-     *  The kinetic energy is a single particle operator. This method can be
-     *  used to retrieve the particle whose kinetic energy is described by
-     *  *this.
-     *
-     *  This is a convenience function for calling the base class's at member.
-     *
-     *  @return A mutable reference to the particle.
-     *
-     *  @throw None No throw guarantee.
-     */
-    reference particle() { return base_type::template at<0>(); }
-
     /** @brief Returns a read-only reference to the particle.
-     *
-     *  This method is the same as the non-const version except that the result
-     *  is read-only.
      *
      *  @return A read-only reference to the particle.
      *
      *  @throw None No throw guarantee.
      */
-    const_reference particle() const { return base_type::template at<0>(); }
+    const_reference get_particle() const {
+        return base_type::template get<0>();
+    }
+
+    /** @brief Update the value of the particle
+     *
+     *  @param[in] p The new value of the particle.
+     *
+     *  @throw None No throw guarantee.
+     */
+    void set_particle(value_type p) {
+        base_type::template set<0>(std::move(p));
+    }
 };
 
 extern template class Kinetic<Electron>;

--- a/include/chemist/traits/density_traits.hpp
+++ b/include/chemist/traits/density_traits.hpp
@@ -30,8 +30,8 @@ struct ChemistClassTraits<Density<ParticleTypes...>> {
     using value_type      = Density<ParticleTypes...>;
     using reference       = value_type&;
     using const_reference = const value_type&;
-    using view_type       = value_type;
-    using const_view_type = value_type;
+    using view_type       = value_type&;
+    using const_view_type = const value_type&;
 };
 
 template<typename... ParticleTypes>
@@ -39,8 +39,8 @@ struct ChemistClassTraits<const Density<ParticleTypes...>> {
     using value_type      = Density<ParticleTypes...>;
     using reference       = const value_type&;
     using const_reference = const value_type&;
-    using view_type       = value_type;
-    using const_view_type = value_type;
+    using view_type       = const value_type&;
+    using const_view_type = const value_type&;
 };
 
 template<typename... ParticleTypes>
@@ -48,8 +48,8 @@ struct ChemistClassTraits<DecomposableDensity<ParticleTypes...>> {
     using value_type      = DecomposableDensity<ParticleTypes...>;
     using reference       = value_type&;
     using const_reference = const value_type&;
-    using view_type       = value_type;
-    using const_view_type = value_type;
+    using view_type       = value_type&;
+    using const_view_type = const value_type&;
 };
 
 template<typename... ParticleTypes>
@@ -57,8 +57,8 @@ struct ChemistClassTraits<const DecomposableDensity<ParticleTypes...>> {
     using value_type      = DecomposableDensity<ParticleTypes...>;
     using reference       = const value_type&;
     using const_reference = const value_type&;
-    using view_type       = value_type;
-    using const_view_type = value_type;
+    using view_type       = const value_type&;
+    using const_view_type = const value_type&;
 };
 
 } // namespace chemist

--- a/src/python/nucleus/export_nuclei_view.cpp
+++ b/src/python/nucleus/export_nuclei_view.cpp
@@ -20,17 +20,23 @@
 #include <sstream>
 
 namespace chemist {
+namespace detail_ {
 
-void export_nuclei_view(python_module_reference m) {
+template<typename NucleiType>
+void export_nuclei_view_(const char* name, python_module_reference m) {
     // N.B. We don't want to export the base class so we use lambdas to
     //      call the methods.
 
-    using nuclei_type = Nuclei;
+    using nuclei_type = NucleiType;
     using view_type   = NucleiView<nuclei_type>;
     using reference   = view_type&;
     using size_type   = typename nuclei_type::size_type;
+    using other_nuclei_type =
+      std::conditional_t<std::is_const_v<nuclei_type>, nuclei_type,
+                         const nuclei_type>;
+    using other_view_type = NucleiView<other_nuclei_type>;
 
-    python_class_type<view_type>(m, "NucleiView")
+    python_class_type<view_type>(m, name)
       .def(pybind11::init<>())
       .def(pybind11::init<nuclei_type&>())
       .def("empty", [](reference self) { return self.empty(); })
@@ -51,8 +57,19 @@ void export_nuclei_view(python_module_reference m) {
         pybind11::keep_alive<0, 1>())
       .def(pybind11::self == pybind11::self)
       .def(pybind11::self == nuclei_type{})
+      .def(nuclei_type{} == pybind11::self)
+      .def(pybind11::self == other_view_type{})
       .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != nuclei_type{});
+      .def(pybind11::self != nuclei_type{})
+      .def(nuclei_type{} != pybind11::self)
+      .def(pybind11::self != other_view_type{});
+}
+
+} // namespace detail_
+
+void export_nuclei_view(python_module_reference m) {
+    detail_::export_nuclei_view_<Nuclei>("NucleiView", m);
+    detail_::export_nuclei_view_<const Nuclei>("ImmutableNucleiView", m);
 }
 
 } // namespace chemist

--- a/src/python/nucleus/export_nucleus_view.cpp
+++ b/src/python/nucleus/export_nucleus_view.cpp
@@ -21,7 +21,9 @@
 
 namespace chemist {
 
-void export_nucleus_view(python_module_reference m) {
+namespace detail_ {
+
+void export_mutable_view(python_module_reference m) {
     using nucleus_type       = Nucleus;
     using view_type          = NucleusView<nucleus_type>;
     using view_reference     = view_type&;
@@ -56,6 +58,41 @@ void export_nucleus_view(python_module_reference m) {
       .def(pybind11::self != pybind11::self)
       .def(pybind11::self != nucleus_type())
       .def(nucleus_type() != pybind11::self);
+}
+
+void export_immutable_view(python_module_reference m) {
+    using nucleus_type      = Nucleus;
+    using view_type         = NucleusView<const nucleus_type>;
+    using view_reference    = view_type&;
+    using nucleus_reference = typename view_type::nucleus_reference;
+    using charge_view_type  = typename view_type::charge_view_type;
+
+    python_class_type<view_type, charge_view_type>(m, "ImmutableNucleusView")
+      .def(pybind11::init<nucleus_reference>())
+      .def_property_readonly("name",
+                             [](view_reference self) { return self.name(); })
+      .def_property_readonly("Z", [](view_reference self) { return self.Z(); })
+      .def_property_readonly("mass",
+                             [](view_reference self) { return self.mass(); })
+      .def("__str__",
+           [](const view_type& nv) {
+               std::ostringstream stream;
+               stream << nv;
+               return stream.str();
+           })
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self == nucleus_type())
+      .def(nucleus_type() == pybind11::self)
+      .def(pybind11::self != pybind11::self)
+      .def(pybind11::self != nucleus_type())
+      .def(nucleus_type() != pybind11::self);
+}
+
+} // namespace detail_
+
+void export_nucleus_view(python_module_reference m) {
+    detail_::export_mutable_view(m);
+    detail_::export_immutable_view(m);
 }
 
 } // namespace chemist

--- a/src/python/point/export_point_view.cpp
+++ b/src/python/point/export_point_view.cpp
@@ -22,7 +22,7 @@ namespace chemist {
 namespace detail_ {
 
 template<typename T>
-inline void export_point_view_(const char* name, python_module_reference m) {
+inline void export_mutable_(const char* name, python_module_reference m) {
     using point_type      = Point<T>;
     using point_view_type = PointView<point_type>;
     using coord_type      = typename point_view_type::coord_type;
@@ -51,11 +51,36 @@ inline void export_point_view_(const char* name, python_module_reference m) {
       .def(pybind11::self != point_type());
 }
 
+template<typename T>
+inline void export_immutable_(const char* name, python_module_reference m) {
+    using point_type      = Point<T>;
+    using point_view_type = PointView<const point_type>;
+    using coord_reference = typename point_view_type::coord_reference;
+    using size_type       = typename point_view_type::size_type;
+
+    using coord_fxn = coord_reference (point_view_type::*)(size_type);
+
+    python_class_type<point_view_type>(m, name)
+      .def(pybind11::init<point_type&>())
+      .def("coord", static_cast<coord_fxn>(&point_view_type::coord))
+      .def_property_readonly("x", [](point_view_type& p) { return p.x(); })
+      .def_property_readonly("y", [](point_view_type& p) { return p.y(); })
+      .def_property_readonly("z", [](point_view_type& p) { return p.z(); })
+      .def("magnitude", &point_view_type::magnitude)
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self == point_type())
+      .def(point_type() == pybind11::self)
+      .def(pybind11::self != pybind11::self)
+      .def(pybind11::self != point_type());
+}
+
 } // namespace detail_
 
 void export_point_view(python_module_reference m) {
-    detail_::export_point_view_<float>("PointViewF", m);
-    detail_::export_point_view_<double>("PointViewD", m);
+    detail_::export_mutable_<float>("PointViewF", m);
+    detail_::export_mutable_<double>("PointViewD", m);
+    detail_::export_immutable_<float>("ImmutablePointViewF", m);
+    detail_::export_immutable_<double>("ImmutablePointViewD", m);
 }
 
 } // namespace chemist

--- a/src/python/point_charge/export_charge_view.cpp
+++ b/src/python/point_charge/export_charge_view.cpp
@@ -22,7 +22,7 @@ namespace chemist {
 namespace detail_ {
 
 template<typename T>
-void export_charge_view_(const char* name, python_module_reference m) {
+void export_mutable_view_(const char* name, python_module_reference m) {
     using point_charge_type = PointCharge<T>;
     using charge_view_type  = PointChargeView<point_charge_type>;
     using charge_type       = typename charge_view_type::charge_type;
@@ -35,7 +35,26 @@ void export_charge_view_(const char* name, python_module_reference m) {
       .def_property(
         "charge", [](charge_view_type& self) { return self.charge(); },
         [](charge_view_type& self, charge_type q) { self.charge() = q; })
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self == point_charge_type())
+      .def(point_charge_type() == pybind11::self)
+      .def(pybind11::self != pybind11::self)
+      .def(pybind11::self != point_charge_type())
+      .def(point_charge_type() != pybind11::self);
+}
 
+template<typename T>
+void export_immutable_view_(const char* name, python_module_reference m) {
+    using point_charge_type = PointCharge<T>;
+    using charge_view_type  = PointChargeView<const point_charge_type>;
+    using point_charge_reference =
+      typename charge_view_type::point_charge_reference;
+    using point_view_type = typename charge_view_type::point_view_type;
+
+    python_class_type<charge_view_type, point_view_type>(m, name)
+      .def(pybind11::init<point_charge_reference>())
+      .def_property_readonly(
+        "charge", [](charge_view_type& self) { return self.charge(); })
       .def(pybind11::self == pybind11::self)
       .def(pybind11::self == point_charge_type())
       .def(point_charge_type() == pybind11::self)
@@ -47,8 +66,10 @@ void export_charge_view_(const char* name, python_module_reference m) {
 } // namespace detail_
 
 void export_charge_view(python_module_reference m) {
-    detail_::export_charge_view_<float>("PointChargeViewF", m);
-    detail_::export_charge_view_<double>("PointChargeViewD", m);
+    detail_::export_mutable_view_<float>("PointChargeViewF", m);
+    detail_::export_mutable_view_<double>("PointChargeViewD", m);
+    detail_::export_immutable_view_<float>("ImmutablePointChargeViewF", m);
+    detail_::export_immutable_view_<double>("ImmutablePointChargeViewD", m);
 }
 
 } // namespace chemist

--- a/src/python/quantum_mechanics/operator/export_coulomb.cpp
+++ b/src/python/quantum_mechanics/operator/export_coulomb.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "export_operator.hpp"
+#include <chemist/quantum_mechanics/operator/coulomb.hpp>
+#include <pybind11/operators.h>
+
+namespace chemist::qm_operator {
+
+template<typename T, typename U>
+void export_coulomb_(const char* name, python_module_reference m) {
+    using coulomb_t = Coulomb<T, U>;
+
+    auto get_lhs_particle = [](const coulomb_t& o) {
+        return o.get_lhs_particle();
+    };
+    auto set_lhs_particle = [](coulomb_t& o, T& p) { o.set_lhs_particle(p); };
+    auto get_rhs_particle = [](const coulomb_t& o) {
+        return o.get_rhs_particle();
+    };
+    auto set_rhs_particle = [](coulomb_t& o, U& p) { o.set_rhs_particle(p); };
+
+    python_class_type<coulomb_t>(m, name)
+      .def(pybind11::init<>())
+      .def(pybind11::init<T, U>())
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self != pybind11::self)
+      .def_property("lhs_particle", get_lhs_particle, set_lhs_particle)
+      .def_property("rhs_particle", get_rhs_particle, set_rhs_particle);
+}
+
+void export_coulomb(python_module_reference m) {
+    export_coulomb_<Electron, Electron>("CoulombElectronElectron", m);
+    export_coulomb_<ManyElectrons, ManyElectrons>(
+      "CoulombManyElectronsManyElectrons", m);
+    export_coulomb_<Electron, chemist::Density<Electron>>(
+      "CoulombElectronDensityElectron", m);
+    export_coulomb_<ManyElectrons, chemist::Density<Electron>>(
+      "CoulombManyElectronsDensityElectrons", m);
+    export_coulomb_<Electron, DecomposableDensity<Electron>>(
+      "CoulombElectronDecomposableDensityElectron", m);
+    export_coulomb_<ManyElectrons, DecomposableDensity<Electron>>(
+      "CoulombManyElectronsDecomposableDensityElectron", m);
+    export_coulomb_<Electron, Nuclei>("CoulombElectronNuclei", m);
+    export_coulomb_<ManyElectrons, Nuclei>("CoulombManyElectronsNuclei", m);
+    export_coulomb_<Nuclei, Nuclei>("CoulombNucleiNuclei", m);
+}
+
+} // namespace chemist::qm_operator

--- a/src/python/quantum_mechanics/operator/export_exchange.cpp
+++ b/src/python/quantum_mechanics/operator/export_exchange.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "export_operator.hpp"
+#include <chemist/quantum_mechanics/operator/exchange.hpp>
+#include <pybind11/operators.h>
+
+namespace chemist::qm_operator {
+
+template<typename T, typename U>
+void export_exchange_(const char* name, python_module_reference m) {
+    using exchange_t = Exchange<T, U>;
+
+    auto get_lhs_particle = [](const exchange_t& o) {
+        return o.get_lhs_particle();
+    };
+    auto set_lhs_particle = [](exchange_t& o, T& p) { o.set_lhs_particle(p); };
+    auto get_rhs_particle = [](const exchange_t& o) {
+        return o.get_rhs_particle();
+    };
+    auto set_rhs_particle = [](exchange_t& o, U& p) { o.set_rhs_particle(p); };
+
+    python_class_type<exchange_t>(m, name)
+      .def(pybind11::init<>())
+      .def(pybind11::init<T, U>())
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self != pybind11::self)
+      .def_property("lhs_particle", get_lhs_particle, set_lhs_particle)
+      .def_property("rhs_particle", get_rhs_particle, set_rhs_particle);
+}
+
+void export_exchange(python_module_reference m) {
+    export_exchange_<Electron, chemist::Density<Electron>>(
+      "ExchangeElectronDensityElectron", m);
+    export_exchange_<ManyElectrons, chemist::Density<Electron>>(
+      "ExchangeManyElectronsDensityElectron", m);
+    export_exchange_<Electron, DecomposableDensity<Electron>>(
+      "ExchangeElectronDecomposableDensityElectron", m);
+    export_exchange_<ManyElectrons, DecomposableDensity<Electron>>(
+      "ExchangeManyElectronsDecomposableDensityElectron", m);
+}
+
+} // namespace chemist::qm_operator

--- a/src/python/quantum_mechanics/operator/export_exchange_correlation.cpp
+++ b/src/python/quantum_mechanics/operator/export_exchange_correlation.cpp
@@ -17,10 +17,11 @@
 #include "export_operator.hpp"
 #include <chemist/quantum_mechanics/operator/exchange_correlation.hpp>
 #include <pybind11/native_enum.h>
+#include <pybind11/operators.h>
 
 namespace chemist::qm_operator {
 
-void export_xc_functionals(python_module_reference m) {
+void export_xc_functionals_(python_module_reference m) {
     python_enum_type<xc_functional>(m, "xc_functional", "enum.Enum")
       .value("NONE", xc_functional::NONE)
       .value("CUSTOM", xc_functional::CUSTOM)
@@ -32,6 +33,45 @@ void export_xc_functionals(python_module_reference m) {
       .value("revPBE", xc_functional::revPBE)
       .value("PBE0", xc_functional::PBE0)
       .finalize();
+}
+
+template<typename T, typename U>
+void export_exchange_correlation_(const char* name, python_module_reference m) {
+    using xc_t = ExchangeCorrelation<T, U>;
+
+    auto get_lhs_particle = [](const xc_t& o) { return o.get_lhs_particle(); };
+    auto set_lhs_particle = [](xc_t& o, T& p) { o.set_lhs_particle(p); };
+    auto get_rhs_particle = [](const xc_t& o) { return o.get_rhs_particle(); };
+    auto set_rhs_particle = [](xc_t& o, U& p) { o.set_rhs_particle(p); };
+    auto get_functional_name = [](const xc_t& o) {
+        return o.get_functional_name();
+    };
+    auto set_functional_name = [](xc_t& o, xc_functional& p) {
+        o.set_functional_name(p);
+    };
+
+    python_class_type<xc_t>(m, name)
+      .def(pybind11::init<>())
+      .def(pybind11::init<xc_functional, T, U>())
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self != pybind11::self)
+      .def_property("lhs_particle", get_lhs_particle, set_lhs_particle)
+      .def_property("rhs_particle", get_rhs_particle, set_rhs_particle)
+      .def_property("functional_name", get_functional_name,
+                    set_functional_name);
+}
+
+void export_exchange_correlation(python_module_reference m) {
+    export_xc_functionals_(m);
+
+    export_exchange_correlation_<Electron, chemist::Density<Electron>>(
+      "ExchangeCorrelationElectronDensityElectron", m);
+    export_exchange_correlation_<ManyElectrons, chemist::Density<Electron>>(
+      "ExchangeCorrelationManyElectronsDensityElectrons", m);
+    export_exchange_correlation_<Electron, DecomposableDensity<Electron>>(
+      "ExchangeCorrelationElectronDecomposableDensityElectron", m);
+    export_exchange_correlation_<ManyElectrons, DecomposableDensity<Electron>>(
+      "ExchangeCorrelationManyElectronsDecomposableDensityElectron", m);
 }
 
 } // namespace chemist::qm_operator

--- a/src/python/quantum_mechanics/operator/export_identity.cpp
+++ b/src/python/quantum_mechanics/operator/export_identity.cpp
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-#pragma once
-#include "../../pychemist.hpp"
+#include "export_operator.hpp"
+#include <chemist/quantum_mechanics/operator/identity.hpp>
+#include <pybind11/operators.h>
 
 namespace chemist::qm_operator {
 
-void export_identity(python_module_reference m);
-void export_xc_functionals(python_module_reference m);
-
-inline void export_qm_operator(python_module_reference m) {
-    auto m_op = m.def_submodule("qm_operator");
-
-    export_identity(m_op);
-    export_xc_functionals(m_op);
+void export_identity(python_module_reference m) {
+    python_class_type<Identity>(m, "Identity")
+      .def(pybind11::init<>())
+      .def(pybind11::self == pybind11::self)
+      .def(pybind11::self != pybind11::self);
 }
 
 } // namespace chemist::qm_operator

--- a/src/python/quantum_mechanics/operator/export_kinetic.cpp
+++ b/src/python/quantum_mechanics/operator/export_kinetic.cpp
@@ -15,16 +15,31 @@
  */
 
 #include "export_operator.hpp"
-#include <chemist/quantum_mechanics/operator/identity.hpp>
+#include <chemist/quantum_mechanics/operator/kinetic.hpp>
 #include <pybind11/operators.h>
 
 namespace chemist::qm_operator {
 
-void export_identity(python_module_reference m) {
-    python_class_type<Identity>(m, "Identity")
+template<typename T>
+void export_kinetic_(const char* name, python_module_reference m) {
+    using kinetic_t = Kinetic<T>;
+
+    auto get_particle = [](const kinetic_t& k) { return k.get_particle(); };
+    auto set_particle = [](kinetic_t& k, T& p) { k.set_particle(p); };
+
+    python_class_type<kinetic_t>(m, name)
       .def(pybind11::init<>())
+      .def(pybind11::init<T>())
       .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(pybind11::self != pybind11::self)
+      .def_property("particle", get_particle, set_particle);
+}
+
+void export_kinetic(python_module_reference m) {
+    export_kinetic_<Electron>("KineticElectron", m);
+    export_kinetic_<ManyElectrons>("KineticManyElectrons", m);
+    export_kinetic_<Nucleus>("KineticNuclues", m);
+    export_kinetic_<Nuclei>("KineticNuclei", m);
 }
 
 } // namespace chemist::qm_operator

--- a/src/python/quantum_mechanics/operator/export_operator.hpp
+++ b/src/python/quantum_mechanics/operator/export_operator.hpp
@@ -20,13 +20,19 @@
 namespace chemist::qm_operator {
 
 void export_identity(python_module_reference m);
-void export_xc_functionals(python_module_reference m);
+void export_kinetic(python_module_reference m);
+void export_coulomb(python_module_reference m);
+void export_exchange(python_module_reference m);
+void export_exchange_correlation(python_module_reference m);
 
 inline void export_qm_operator(python_module_reference m) {
     auto m_op = m.def_submodule("qm_operator");
 
     export_identity(m_op);
-    export_xc_functionals(m_op);
+    export_kinetic(m_op);
+    export_coulomb(m_op);
+    export_exchange(m_op);
+    export_exchange_correlation(m_op);
 }
 
 } // namespace chemist::qm_operator

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/coulomb.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/coulomb.cpp
@@ -49,35 +49,35 @@ TEMPLATE_LIST_TEST_CASE("Coulomb", "", types2test) {
 
     SECTION("Ctors and assignment") {
         SECTION("Defaulted") {
-            REQUIRE(defaulted.lhs_particle() == corr_lhs_defaulted);
-            REQUIRE(defaulted.rhs_particle() == corr_rhs_defaulted);
+            REQUIRE(defaulted.get_lhs_particle() == corr_lhs_defaulted);
+            REQUIRE(defaulted.get_rhs_particle() == corr_rhs_defaulted);
         }
 
         SECTION("Value") {
-            REQUIRE(value.lhs_particle() == corr_lhs_value);
-            REQUIRE(value.rhs_particle() == corr_rhs_value);
+            REQUIRE(value.get_lhs_particle() == corr_lhs_value);
+            REQUIRE(value.get_rhs_particle() == corr_rhs_value);
         }
 
         test_chemist::test_copy_and_move(defaulted, value);
     }
 
-    SECTION("lhs_particle()") {
-        REQUIRE(defaulted.lhs_particle() == corr_lhs_defaulted);
-        REQUIRE(value.lhs_particle() == corr_lhs_value);
+    SECTION("get_lhs_particle()") {
+        REQUIRE(defaulted.get_lhs_particle() == corr_lhs_defaulted);
+        REQUIRE(value.get_lhs_particle() == corr_lhs_value);
     }
 
-    SECTION("lhs_particle() const") {
-        REQUIRE(std::as_const(defaulted).lhs_particle() == corr_lhs_defaulted);
-        REQUIRE(std::as_const(value).lhs_particle() == corr_lhs_value);
+    SECTION("set_lhs_particle()") {
+        defaulted.set_lhs_particle(corr_lhs_value);
+        REQUIRE(defaulted.get_lhs_particle() == corr_lhs_value);
     }
 
-    SECTION("rhs_particle()") {
-        REQUIRE(defaulted.rhs_particle() == corr_rhs_defaulted);
-        REQUIRE(value.rhs_particle() == corr_rhs_value);
+    SECTION("get_rhs_particle()") {
+        REQUIRE(defaulted.get_rhs_particle() == corr_rhs_defaulted);
+        REQUIRE(value.get_rhs_particle() == corr_rhs_value);
     }
 
-    SECTION("rhs_particle() const") {
-        REQUIRE(std::as_const(defaulted).rhs_particle() == corr_rhs_defaulted);
-        REQUIRE(std::as_const(value).rhs_particle() == corr_rhs_value);
+    SECTION("set_rhs_particle()") {
+        defaulted.set_rhs_particle(corr_rhs_value);
+        REQUIRE(defaulted.get_rhs_particle() == corr_rhs_value);
     }
 }

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/detail_/operator_impl.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/detail_/operator_impl.cpp
@@ -44,17 +44,17 @@ TEST_CASE("OperatorImpl") {
 
     SECTION("n_electrons") {
         STATIC_REQUIRE(t.n_electrons() == 1);
-        STATIC_REQUIRE(t.n_electrons() == 1);
+        STATIC_REQUIRE(T.n_electrons() == 1);
     }
 
-    SECTION("at()") {
-        REQUIRE(t.at<0>() == Electron{});
-        REQUIRE(T.at<0>() == ManyElectrons{2});
+    SECTION("get()") {
+        REQUIRE(t.get<0>() == Electron{});
+        REQUIRE(T.get<0>() == ManyElectrons{2});
     }
 
-    SECTION("at() const") {
-        REQUIRE(std::as_const(t).at<0>() == Electron{});
-        REQUIRE(std::as_const(T).at<0>() == ManyElectrons{2});
+    SECTION("set()") {
+        T.set<0>(ManyElectrons{3});
+        REQUIRE(T.get<0>() == ManyElectrons{3});
     }
 
     SECTION("operator==") {

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/exchange.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/exchange.cpp
@@ -45,35 +45,34 @@ TEMPLATE_LIST_TEST_CASE("Exchange", "", types2test) {
 
     SECTION("Ctors and assignment") {
         SECTION("Defaulted") {
-            REQUIRE(defaulted.lhs_particle() == corr_lhs_defaulted);
-            REQUIRE(defaulted.rhs_particle() == corr_rhs_defaulted);
+            REQUIRE(defaulted.get_lhs_particle() == corr_lhs_defaulted);
+            REQUIRE(defaulted.get_rhs_particle() == corr_rhs_defaulted);
         }
 
         SECTION("Value") {
-            REQUIRE(value.lhs_particle() == corr_lhs_value);
-            REQUIRE(value.rhs_particle() == corr_rhs_value);
+            REQUIRE(value.get_lhs_particle() == corr_lhs_value);
+            REQUIRE(value.get_rhs_particle() == corr_rhs_value);
         }
 
         test_chemist::test_copy_and_move(defaulted, value);
     }
 
     SECTION("lhs_particle()") {
-        REQUIRE(defaulted.lhs_particle() == corr_lhs_defaulted);
-        REQUIRE(value.lhs_particle() == corr_lhs_value);
+        REQUIRE(defaulted.get_lhs_particle() == corr_lhs_defaulted);
+        REQUIRE(value.get_lhs_particle() == corr_lhs_value);
+
+        // Test writing
+        defaulted.set_lhs_particle(corr_lhs_value);
+        REQUIRE(defaulted.get_lhs_particle() == corr_lhs_value);
     }
 
-    SECTION("lhs_particle() const") {
-        REQUIRE(std::as_const(defaulted).lhs_particle() == corr_lhs_defaulted);
-        REQUIRE(std::as_const(value).lhs_particle() == corr_lhs_value);
+    SECTION("get_rhs_particle()") {
+        REQUIRE(defaulted.get_rhs_particle() == corr_rhs_defaulted);
+        REQUIRE(value.get_rhs_particle() == corr_rhs_value);
     }
 
-    SECTION("rhs_particle()") {
-        REQUIRE(defaulted.rhs_particle() == corr_rhs_defaulted);
-        REQUIRE(value.rhs_particle() == corr_rhs_value);
-    }
-
-    SECTION("rhs_particle() const") {
-        REQUIRE(std::as_const(defaulted).rhs_particle() == corr_rhs_defaulted);
-        REQUIRE(std::as_const(value).rhs_particle() == corr_rhs_value);
+    SECTION("set_rhs_particle()") {
+        defaulted.set_rhs_particle(corr_rhs_value);
+        REQUIRE(defaulted.get_rhs_particle() == corr_rhs_value);
     }
 }

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/exchange_correlation.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/exchange_correlation.cpp
@@ -45,48 +45,47 @@ TEMPLATE_LIST_TEST_CASE("ExchangeCorrelation", "", types2test) {
 
     SECTION("Ctors and assignment") {
         SECTION("Defaulted") {
-            REQUIRE(defaulted.lhs_particle() == corr_lhs_defaulted);
-            REQUIRE(defaulted.rhs_particle() == corr_rhs_defaulted);
-            REQUIRE(defaulted.functional_name() == xc_functional::NONE);
+            REQUIRE(defaulted.get_lhs_particle() == corr_lhs_defaulted);
+            REQUIRE(defaulted.get_rhs_particle() == corr_rhs_defaulted);
+            REQUIRE(defaulted.get_functional_name() == xc_functional::NONE);
         }
 
         SECTION("Value") {
-            REQUIRE(value.lhs_particle() == corr_lhs_value);
-            REQUIRE(value.rhs_particle() == corr_rhs_value);
-            REQUIRE(value.functional_name() == xc_functional::PBE);
+            REQUIRE(value.get_lhs_particle() == corr_lhs_value);
+            REQUIRE(value.get_rhs_particle() == corr_rhs_value);
+            REQUIRE(value.get_functional_name() == xc_functional::PBE);
         }
 
         test_chemist::test_copy_and_move(defaulted, value);
     }
 
-    SECTION("lhs_particle()") {
-        REQUIRE(defaulted.lhs_particle() == corr_lhs_defaulted);
-        REQUIRE(value.lhs_particle() == corr_lhs_value);
+    SECTION("get_lhs_particle()") {
+        REQUIRE(defaulted.get_lhs_particle() == corr_lhs_defaulted);
+        REQUIRE(value.get_lhs_particle() == corr_lhs_value);
     }
 
-    SECTION("lhs_particle() const") {
-        REQUIRE(std::as_const(defaulted).lhs_particle() == corr_lhs_defaulted);
-        REQUIRE(std::as_const(value).lhs_particle() == corr_lhs_value);
+    SECTION("set_lhs_particle()") {
+        defaulted.set_lhs_particle(corr_lhs_value);
+        REQUIRE(defaulted.get_lhs_particle() == corr_lhs_value);
     }
 
-    SECTION("rhs_particle()") {
-        REQUIRE(defaulted.rhs_particle() == corr_rhs_defaulted);
-        REQUIRE(value.rhs_particle() == corr_rhs_value);
+    SECTION("get_rhs_particle()") {
+        REQUIRE(defaulted.get_rhs_particle() == corr_rhs_defaulted);
+        REQUIRE(value.get_rhs_particle() == corr_rhs_value);
     }
 
-    SECTION("rhs_particle() const") {
-        REQUIRE(std::as_const(defaulted).rhs_particle() == corr_rhs_defaulted);
-        REQUIRE(std::as_const(value).rhs_particle() == corr_rhs_value);
+    SECTION("set_rhs_particle()") {
+        defaulted.set_rhs_particle(corr_rhs_value);
+        REQUIRE(defaulted.get_rhs_particle() == corr_rhs_value);
     }
 
-    SECTION("functional_name()") {
-        REQUIRE(defaulted.functional_name() == xc_functional::NONE);
-        REQUIRE(value.functional_name() == xc_functional::PBE);
+    SECTION("get_functional_name()") {
+        REQUIRE(defaulted.get_functional_name() == xc_functional::NONE);
+        REQUIRE(value.get_functional_name() == xc_functional::PBE);
     }
 
-    SECTION("functional_name() const") {
-        REQUIRE(std::as_const(defaulted).functional_name() ==
-                xc_functional::NONE);
-        REQUIRE(std::as_const(value).functional_name() == xc_functional::PBE);
+    SECTION("set_functional_name()") {
+        defaulted.set_functional_name(xc_functional::PBE);
+        REQUIRE(defaulted.get_functional_name() == xc_functional::PBE);
     }
 }

--- a/tests/cxx/unit_tests/quantum_mechanics/operator/kinetic.cpp
+++ b/tests/cxx/unit_tests/quantum_mechanics/operator/kinetic.cpp
@@ -36,21 +36,21 @@ TEMPLATE_LIST_TEST_CASE("Kinetic", "", types2test) {
 
     SECTION("Ctors and assignment") {
         SECTION("Defaulted") {
-            REQUIRE(defaulted.particle() == corr_defaulted);
+            REQUIRE(defaulted.get_particle() == corr_defaulted);
         }
 
-        SECTION("Value") { REQUIRE(value.particle() == corr_value); }
+        SECTION("Value") { REQUIRE(value.get_particle() == corr_value); }
 
         test_chemist::test_copy_and_move(defaulted, value);
     }
 
-    SECTION("particle()") {
-        REQUIRE(defaulted.particle() == corr_defaulted);
-        REQUIRE(value.particle() == corr_value);
+    SECTION("get_particle()") {
+        REQUIRE(defaulted.get_particle() == corr_defaulted);
+        REQUIRE(value.get_particle() == corr_value);
     }
 
-    SECTION("particle() const") {
-        REQUIRE(std::as_const(defaulted).particle() == corr_defaulted);
-        REQUIRE(std::as_const(value).particle() == corr_value);
+    SECTION("set_particle()") {
+        defaulted.set_particle(corr_value);
+        REQUIRE(defaulted.get_particle() == corr_value);
     }
 }

--- a/tests/python/unit_tests/chemical_system/nucleus/test_nuclei_view.py
+++ b/tests/python/unit_tests/chemical_system/nucleus/test_nuclei_view.py
@@ -21,6 +21,8 @@ class TestNucleiView(unittest.TestCase):
     def test_empty(self):
         self.assertTrue(self.defaulted.empty())
         self.assertFalse(self.has_value.empty())
+        self.assertTrue(self.immutable_defaulted.empty())
+        self.assertFalse(self.immutable_has_value.empty())
 
     def test_at(self):
         # Check values
@@ -29,13 +31,22 @@ class TestNucleiView(unittest.TestCase):
         self.assertEqual(n0, self.n0)
         self.assertEqual(n1, self.n1)
 
+        n2 = self.immutable_has_value.at(0)
+        self.assertEqual(n2, self.n0)
+
         # Are views
         n0.x = 42.0
         self.assertEqual(self.value_set.at(0).x, 42.0)
 
+        # Can't change it on the immutable view
+        with self.assertRaises(AttributeError):
+            n2.x = 42.0
+
     def test_size(self):
         self.assertEqual(self.defaulted.size(), 0)
         self.assertEqual(self.has_value.size(), 2)
+        self.assertEqual(self.immutable_defaulted.size(), 0)
+        self.assertEqual(self.immutable_has_value.size(), 2)
 
     def test_comparisons(self):
         # Default vs default
@@ -56,6 +67,12 @@ class TestNucleiView(unittest.TestCase):
         self.assertEqual(self.has_value, other_value)
         self.assertFalse(self.has_value != other_value)
 
+        # Mutable vs immutable
+        self.assertEqual(self.immutable_defaulted, other_default)
+        self.assertEqual(self.immutable_has_value, other_value)
+        self.assertFalse(self.immutable_defaulted != other_default)
+        self.assertFalse(self.immutable_has_value != other_value)
+
         # Different order
         diff_order_set = chemist.Nuclei()
         diff_order_set.push_back(self.n1)
@@ -66,15 +83,18 @@ class TestNucleiView(unittest.TestCase):
 
     def test_iter(self):
         # Empty
-        for n in self.defaulted:
-            self.fail("Empty Nuclei should not iterate")
+        for view in [self.defaulted, self.immutable_defaulted]:
+            for n in view:
+                self.fail("Empty Nuclei should not iterate")
 
         # Non-empty
-        for n in self.has_value:
-            self.assertTrue(n == self.n0 or n == self.n1)
+        for view in [self.has_value, self.immutable_has_value]:
+            for n in view:
+                self.assertTrue(n == self.n0 or n == self.n1)
 
     def test_str(self):
         self.assertEqual(str(self.defaulted), "")
+        self.assertEqual(str(self.immutable_defaulted), "")
 
         corr_string = " 0.000000000000000 0.000000000000000 0.000000000000000"
         corr_string += "\n"
@@ -83,6 +103,7 @@ class TestNucleiView(unittest.TestCase):
         )
         corr_string += "\n"
         self.assertEqual(str(self.has_value), corr_string)
+        self.assertEqual(str(self.immutable_has_value), corr_string)
 
     def setUp(self):
         self.defaulted = chemist.NucleiView()
@@ -92,3 +113,5 @@ class TestNucleiView(unittest.TestCase):
         self.value_set.push_back(self.n0)
         self.value_set.push_back(self.n1)
         self.has_value = chemist.NucleiView(self.value_set)
+        self.immutable_defaulted = chemist.ImmutableNucleiView()
+        self.immutable_has_value = chemist.ImmutableNucleiView(self.value_set)

--- a/tests/python/unit_tests/chemical_system/nucleus/test_nucleus_view.py
+++ b/tests/python/unit_tests/chemical_system/nucleus/test_nucleus_view.py
@@ -28,33 +28,37 @@ class TestNucleus(unittest.TestCase):
 
         # Test the default instance
 
-        # -- PointCharge Base ----------------------
-        self.assertEqual(self.defaulted_view.charge, 0.0)
+        for defaulted in [self.defaulted_view, self.immutable_defaulted_view]:
+            # -- PointCharge Base ----------------------
+            self.assertEqual(defaulted.charge, 0.0)
 
-        # -- Point Base ----------------------------
-        self.assertEqual(self.defaulted_view.x, 0.0)
-        self.assertEqual(self.defaulted_view.y, 0.0)
-        self.assertEqual(self.defaulted_view.z, 0.0)
+            # -- Point Base ----------------------------
+            self.assertEqual(defaulted.x, 0.0)
+            self.assertEqual(defaulted.y, 0.0)
+            self.assertEqual(defaulted.z, 0.0)
 
-        for i in range(3):
-            self.assertEqual(self.defaulted_view.coord(i), 0.0)
+            for i in range(3):
+                self.assertEqual(defaulted.coord(i), 0.0)
 
-        self.assertEqual(self.defaulted_view.magnitude(), 0.0)
+            self.assertEqual(defaulted.magnitude(), 0.0)
 
         # Repeat, this time with u_view
-        self.assertEqual(self.u_view.charge, 91.0)
-        self.assertEqual(self.u_view.x, 2.0)
-        self.assertEqual(self.u_view.y, 3.0)
-        self.assertEqual(self.u_view.z, 4.0)
-        self.assertEqual(self.u_view.coord(0), 2.0)
-        self.assertEqual(self.u_view.coord(1), 3.0)
-        self.assertEqual(self.u_view.coord(2), 4.0)
-        self.assertAlmostEqual(self.u_view.magnitude(), 29.0**0.5)
+        for u_view in [self.u_view, self.immutable_u_view]:
+            self.assertEqual(u_view.charge, 91.0)
+            self.assertEqual(u_view.x, 2.0)
+            self.assertEqual(u_view.y, 3.0)
+            self.assertEqual(u_view.z, 4.0)
+            self.assertEqual(u_view.coord(0), 2.0)
+            self.assertEqual(u_view.coord(1), 3.0)
+            self.assertEqual(u_view.coord(2), 4.0)
+            self.assertAlmostEqual(u_view.magnitude(), 29.0**0.5)
 
     def test_name(self):
         # Test original values
         self.assertEqual(self.defaulted_view.name, "")
+        self.assertEqual(self.immutable_defaulted_view.name, "")
         self.assertEqual(self.u_view.name, "U")
+        self.assertEqual(self.immutable_u_view.name, "U")
 
         # Can change it
         self.defaulted_view.name = "Ez"
@@ -62,6 +66,10 @@ class TestNucleus(unittest.TestCase):
 
         # Changes object it's a view of
         self.assertEqual(self.defaulted.name, "Ez")
+
+        # Can't change it on the immutable view
+        with self.assertRaises(AttributeError):
+            self.immutable_defaulted_view.name = "Ez"
 
     def test_Z(self):
         # Test original values
@@ -75,6 +83,10 @@ class TestNucleus(unittest.TestCase):
         # Changes object it's a view of
         self.assertEqual(self.defaulted.Z, 6)
 
+        # Can't change it on the immutable view
+        with self.assertRaises(AttributeError):
+            self.immutable_defaulted_view.Z = 6
+
     def test_mass(self):
         # Test original values
         self.assertEqual(self.defaulted_view.mass, 0.0)
@@ -86,6 +98,10 @@ class TestNucleus(unittest.TestCase):
 
         # Changes object it's a view of
         self.assertEqual(self.defaulted.mass, 1.234)
+
+        # Can't change it on the immutable view
+        with self.assertRaises(AttributeError):
+            self.immutable_defaulted_view.mass = 1.234
 
     def test_comparisons(self):
         # Default view vs. default view
@@ -188,19 +204,25 @@ class TestNucleus(unittest.TestCase):
 
     def test_str(self):
         # Default
-        self.assertEqual(
-            str(self.defaulted_view),
-            " 0.000000000000000 0.000000000000000 0.000000000000000",
-        )
+        for defaulted in [self.defaulted_view, self.immutable_defaulted_view]:
+            self.assertEqual(
+                str(defaulted),
+                " 0.000000000000000 0.000000000000000 0.000000000000000",
+            )
 
         # Has value
-        self.assertEqual(
-            str(self.u_view),
-            "U 2.000000000000000 3.000000000000000 4.000000000000000",
-        )
+        for u_view in [self.u_view, self.immutable_u_view]:
+            self.assertEqual(
+                str(u_view),
+                "U 2.000000000000000 3.000000000000000 4.000000000000000",
+            )
 
     def setUp(self):
         self.defaulted = chemist.Nucleus()
         self.defaulted_view = chemist.NucleusView(self.defaulted)
         self.u = chemist.Nucleus("U", 92, 238.0, 2.0, 3.0, 4.0, 91.0)
         self.u_view = chemist.NucleusView(self.u)
+        self.immutable_defaulted_view = chemist.ImmutableNucleusView(
+            self.defaulted
+        )
+        self.immutable_u_view = chemist.ImmutableNucleusView(self.u)

--- a/tests/python/unit_tests/chemical_system/point_charge/test_charge_view.py
+++ b/tests/python/unit_tests/chemical_system/point_charge/test_charge_view.py
@@ -17,7 +17,7 @@ import unittest
 import chemist
 
 
-def make_charge_view_test(charge_type):
+def make_charge_view_test(view_type):
     class TestChargeView(unittest.TestCase):
         def test_base(self):
             """
@@ -48,7 +48,7 @@ def make_charge_view_test(charge_type):
 
             # N.B. For charge_type == PointChargeF the underlying data type
             #      only has about six decimal places of precision.
-            p = 6 if charge_type == chemist.PointChargeF else 10
+            p = 6 if self.charge_type == chemist.PointChargeF else 10
             self.assertAlmostEqual(
                 self.q1_view.magnitude(), 29**0.5, places=p
             )
@@ -58,17 +58,18 @@ def make_charge_view_test(charge_type):
             self.assertEqual(self.q0_view.charge, 0.0)
             self.assertEqual(self.q1_view.charge, 1.0)
 
-            # Can change it
-            self.q0_view.charge = -42.0
-            self.assertEqual(self.q0_view.charge, -42.0)
+            if self.readonly is False:
+                # Can change it
+                self.q0_view.charge = -42.0
+                self.assertEqual(self.q0_view.charge, -42.0)
 
-            # Changes the actual charge
-            self.assertEqual(self.q0.charge, -42.0)
+                # Changes the actual charge
+                self.assertEqual(self.q0.charge, -42.0)
 
         def test_comparisons(self):
             # Default view vs. default view
-            other_default = charge_type()
-            other_view = self.charge_view_type(other_default)
+            other_default = self.charge_type()
+            other_view = view_type(other_default)
             self.assertEqual(self.q0_view, other_view)
             self.assertFalse(self.q0_view != other_view)
 
@@ -85,26 +86,26 @@ def make_charge_view_test(charge_type):
             self.assertFalse(self.q0_view == self.q1)
 
             # Different charge
-            q1 = charge_type(42.0, 2.0, 3.0, 4.0)
-            q1_view = self.charge_view_type(q1)
+            q1 = self.charge_type(42.0, 2.0, 3.0, 4.0)
+            q1_view = view_type(q1)
             self.assertNotEqual(self.q1_view, q1_view)
             self.assertFalse(self.q1_view == q1_view)
 
             # Different x-coordinate
-            q1 = charge_type(1.0, 42.0, 3.0, 4.0)
-            q1_view = self.charge_view_type(q1)
+            q1 = self.charge_type(1.0, 42.0, 3.0, 4.0)
+            q1_view = view_type(q1)
             self.assertNotEqual(self.q1_view, q1_view)
             self.assertFalse(self.q1_view == q1_view)
 
             # Different y-coordinate
-            q1 = charge_type(1.0, 2.0, 42.0, 4.0)
-            q1_view = self.charge_view_type(q1)
+            q1 = self.charge_type(1.0, 2.0, 42.0, 4.0)
+            q1_view = view_type(q1)
             self.assertNotEqual(self.q1_view, q1_view)
             self.assertFalse(self.q1_view == q1_view)
 
             # Different z-coordinate
-            q1 = charge_type(1.0, 2.0, 3.0, 42.0)
-            q1_view = self.charge_view_type(q1)
+            q1 = self.charge_type(1.0, 2.0, 3.0, 42.0)
+            q1_view = view_type(q1)
             self.assertNotEqual(self.q1_view, q1_view)
             self.assertFalse(self.q1_view == q1_view)
 
@@ -119,26 +120,52 @@ def make_charge_view_test(charge_type):
             self.assertNotEqual(r0_view, self.q1)
 
         def setUp(self):
-            if charge_type == chemist.PointChargeF:
-                self.charge_view_type = chemist.PointChargeViewF
+            if view_type == chemist.PointChargeViewF:
+                self.charge_type = chemist.PointChargeF
                 self.point_type = chemist.PointF
                 self.point_view = chemist.PointViewF
-            else:
-                self.charge_view_type = chemist.PointChargeViewD
+                self.readonly = False
+            elif view_type == chemist.PointChargeViewD:
+                self.charge_type = chemist.PointChargeD
                 self.point_type = chemist.PointD
                 self.point_view = chemist.PointViewD
+                self.readonly = False
+            elif view_type == chemist.ImmutablePointChargeViewF:
+                self.charge_type = chemist.PointChargeF
+                self.point_type = chemist.PointF
+                self.point_view = chemist.ImmutablePointViewF
+                self.readonly = True
+            elif view_type == chemist.ImmutablePointChargeViewD:
+                self.charge_type = chemist.PointChargeD
+                self.point_type = chemist.PointD
+                self.point_view = chemist.ImmutablePointViewD
+                self.readonly = True
+            else:
+                raise ValueError("Invalid charge type")
 
-            self.q0 = charge_type()
-            self.q0_view = self.charge_view_type(self.q0)
-            self.q1 = charge_type(1.0, 2.0, 3.0, 4.0)
-            self.q1_view = self.charge_view_type(self.q1)
+            self.q0 = self.charge_type()
+            self.q0_view = view_type(self.q0)
+            self.q1 = self.charge_type(1.0, 2.0, 3.0, 4.0)
+            self.q1_view = view_type(self.q1)
 
     return TestChargeView
 
 
-class TestChargeViewF(make_charge_view_test(chemist.PointChargeF)):
+class TestChargeViewF(make_charge_view_test(chemist.PointChargeViewF)):
     pass
 
 
-class TestChargeViewD(make_charge_view_test(chemist.PointChargeD)):
+class TestChargeViewD(make_charge_view_test(chemist.PointChargeViewD)):
+    pass
+
+
+class TestImmutableChargeViewF(
+    make_charge_view_test(chemist.ImmutablePointChargeViewF)
+):
+    pass
+
+
+class TestImmutableChargeViewD(
+    make_charge_view_test(chemist.ImmutablePointChargeViewD)
+):
     pass

--- a/tests/python/unit_tests/point/test_point_view.py
+++ b/tests/python/unit_tests/point/test_point_view.py
@@ -14,10 +14,17 @@
 
 import unittest
 
-from chemist import PointD, PointF, PointViewD, PointViewF
+from chemist import (
+    ImmutablePointViewD,
+    ImmutablePointViewF,
+    PointD,
+    PointF,
+    PointViewD,
+    PointViewF,
+)
 
 
-def make_point_view_test_case(point_type, point_view_type):
+def make_point_view_test_case(point_type, point_view_type, readonly=False):
     """
     The test cases for PointViewF vs PointViewD are basically the same aside
     from the types of the class. This function essentially templates the test
@@ -25,7 +32,8 @@ def make_point_view_test_case(point_type, point_view_type):
 
     :param point_type: Either ``PointF`` or ``PointD``
     :param point_view_type: ``PointViewF`` if ``point_type`` is ``PointF`` and
-                            ``PointViewD`` if ``point_type`` is ``PointD``.
+                            ``PointViewD`` if ``point_type`` is ``PointD``
+    :param readonly: True if the view should be readonly, otherwise False.
 
     """
 
@@ -48,49 +56,52 @@ def make_point_view_test_case(point_type, point_view_type):
             # Test the initial value
             self.assertEqual(self.r0_view.x, 1.0)
 
-            # Test we can write to it
-            self.r0_view.x = 2.0
+            if self.readonly is False:
+                # Test we can write to it
+                self.r0_view.x = 2.0
 
-            # Test that our change took
-            self.assertEqual(self.r0.x, 2.0)
-            self.assertEqual(self.r0_view.x, 2.0)
+                # Test that our change took
+                self.assertEqual(self.r0.x, 2.0)
+                self.assertEqual(self.r0_view.x, 2.0)
 
-            # Test that changes to r0 are reflected
-            self.r0.x = 3.0
-            self.assertEqual(self.r0.x, 3.0)
-            self.assertEqual(self.r0_view.x, 3.0)
+                # Test that changes to r0 are reflected
+                self.r0.x = 3.0
+                self.assertEqual(self.r0.x, 3.0)
+                self.assertEqual(self.r0_view.x, 3.0)
 
         def test_y(self):
             # Test the initial value
             self.assertEqual(self.r0_view.y, 2.0)
 
-            # Test we can write to it
-            self.r0_view.y = 3.0
+            if self.readonly is False:
+                # Test we can write to it
+                self.r0_view.y = 3.0
 
-            # Test that our change took
-            self.assertEqual(self.r0.y, 3.0)
-            self.assertEqual(self.r0_view.y, 3.0)
+                # Test that our change took
+                self.assertEqual(self.r0.y, 3.0)
+                self.assertEqual(self.r0_view.y, 3.0)
 
-            # Test that changes to r0 are reflected
-            self.r0.y = 4.0
-            self.assertEqual(self.r0.y, 4.0)
-            self.assertEqual(self.r0_view.y, 4.0)
+                # Test that changes to r0 are reflected
+                self.r0.y = 4.0
+                self.assertEqual(self.r0.y, 4.0)
+                self.assertEqual(self.r0_view.y, 4.0)
 
         def test_z(self):
             # Test the initial value
             self.assertEqual(self.r0_view.z, 3.0)
 
-            # Test we can write to it
-            self.r0_view.z = 4.0
+            if self.readonly is False:
+                # Test we can write to it
+                self.r0_view.z = 4.0
 
-            # Test that our change took
-            self.assertEqual(self.r0.z, 4.0)
-            self.assertEqual(self.r0_view.z, 4.0)
+                # Test that our change took
+                self.assertEqual(self.r0.z, 4.0)
+                self.assertEqual(self.r0_view.z, 4.0)
 
-            # Test that changes to r0 are reflected
-            self.r0.z = 5.0
-            self.assertEqual(self.r0.z, 5.0)
-            self.assertEqual(self.r0_view.z, 5.0)
+                # Test that changes to r0 are reflected
+                self.r0.z = 5.0
+                self.assertEqual(self.r0.z, 5.0)
+                self.assertEqual(self.r0_view.z, 5.0)
 
         def test_magnitude(self):
             self.assertEqual(self.defaulted_view.magnitude(), 0.0)
@@ -138,6 +149,7 @@ def make_point_view_test_case(point_type, point_view_type):
             self.defaulted_view = point_view_type(self.defaulted)
             self.r0 = point_type(1.0, 2.0, 3.0)
             self.r0_view = point_view_type(self.r0)
+            self.readonly = readonly
 
     return TestPointView
 
@@ -147,4 +159,16 @@ class TestPointViewF(make_point_view_test_case(PointF, PointViewF)):
 
 
 class TestPointViewD(make_point_view_test_case(PointD, PointViewD)):
+    pass
+
+
+class TestImmutablePointViewF(
+    make_point_view_test_case(PointF, ImmutablePointViewF, True)
+):
+    pass
+
+
+class TestImmutablePointViewD(
+    make_point_view_test_case(PointD, ImmutablePointViewD, True)
+):
     pass

--- a/tests/python/unit_tests/quantum_mechanics/operators/__init__.py
+++ b/tests/python/unit_tests/quantum_mechanics/operators/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/python/unit_tests/quantum_mechanics/operators/test_coulomb.py
+++ b/tests/python/unit_tests/quantum_mechanics/operators/test_coulomb.py
@@ -16,34 +16,30 @@ import unittest
 
 import numpy as np
 from chemist.qm_operator import (
-    ExchangeCorrelationElectronDensityElectron,
-    ExchangeCorrelationManyElectronsDecomposableDensityElectron,
-    xc_functional,
+    CoulombElectronDensityElectron,
+    CoulombManyElectronsDecomposableDensityElectron,
+    CoulombNucleiNuclei,
 )
 from chemist.wavefunction import AOs
 from tensorwrapper import Tensor
 
-from chemist import DecomposableDensity, Density, Electron, ManyElectrons
+from chemist import (
+    DecomposableDensity,
+    Density,
+    Electron,
+    ManyElectrons,
+    Nuclei,
+    Nucleus,
+)
 from chemist.basis_set import AOBasisSetD
 
 
-class TestXCFunctional(unittest.TestCase):
-    def setUp(self):
-        self.none = xc_functional.NONE
-        self.custom = xc_functional.CUSTOM
-
-    def test_functional_name(self):
-        self.assertEqual(self.none.name, "NONE")
-        self.assertEqual(self.custom.name, "CUSTOM")
-
-    def test_functional_value(self):
-        self.assertEqual(self.none.value, 0)
-        self.assertEqual(self.custom.value, 1)
-
-
-class TestExchangeCorrelation(unittest.TestCase):
+class TestCoulomb(unittest.TestCase):
     def setUp(self):
         # Input Values
+        self.nucleus = Nucleus("H", 1, 1.0, 2.0, 3.0, 4.0, 5.0)
+        self.nuclei = Nuclei()
+        self.nuclei.push_back(self.nucleus)
         self.many_elec = ManyElectrons(4)
         self.tensor = Tensor(np.array([[1.0, 2.0], [3.0, 4.0]]))
         self.basis = AOBasisSetD()
@@ -52,37 +48,26 @@ class TestExchangeCorrelation(unittest.TestCase):
         self.decomp_density = DecomposableDensity(
             self.tensor, self.aos, self.tensor
         )
-        self.xc = xc_functional.PBE
 
         # Test objects
-        self.default1 = ExchangeCorrelationElectronDensityElectron()
-        self.default2 = (
-            ExchangeCorrelationManyElectronsDecomposableDensityElectron()
+        self.default1 = CoulombElectronDensityElectron()
+        self.default2 = CoulombManyElectronsDecomposableDensityElectron()
+        self.default3 = CoulombNucleiNuclei()
+        self.has_value1 = CoulombElectronDensityElectron(
+            Electron(), self.density
         )
-        self.has_value1 = ExchangeCorrelationElectronDensityElectron(
-            self.xc, Electron(), self.density
+        self.has_value2 = CoulombManyElectronsDecomposableDensityElectron(
+            self.many_elec, self.decomp_density
         )
-        self.has_value2 = (
-            ExchangeCorrelationManyElectronsDecomposableDensityElectron(
-                self.xc, self.many_elec, self.decomp_density
-            )
-        )
-
-    def test_functional_name(self):
-        self.assertEqual(self.default1.functional_name, xc_functional.NONE)
-        self.assertEqual(self.default2.functional_name, xc_functional.NONE)
-        self.assertEqual(self.has_value1.functional_name, self.xc)
-        self.assertEqual(self.has_value2.functional_name, self.xc)
-
-        # Check for writing
-        self.default1.functional_name = self.xc
-        self.assertEqual(self.default1.functional_name, self.xc)
+        self.has_value3 = CoulombNucleiNuclei(self.nuclei, self.nuclei)
 
     def test_particles(self):
         self.assertEqual(self.default1.lhs_particle, Electron())
         self.assertEqual(self.default1.rhs_particle, Density())
         self.assertEqual(self.default2.lhs_particle, ManyElectrons())
         self.assertEqual(self.default2.rhs_particle, DecomposableDensity())
+        self.assertEqual(self.default3.lhs_particle, Nuclei())
+        self.assertEqual(self.default3.rhs_particle, Nuclei())
 
         # Check each particle type for writing
         self.default1.rhs_particle = self.density
@@ -91,6 +76,8 @@ class TestExchangeCorrelation(unittest.TestCase):
         self.assertEqual(self.default2.lhs_particle, self.many_elec)
         self.default2.rhs_particle = self.decomp_density
         self.assertEqual(self.default2.rhs_particle, self.decomp_density)
+        self.default3.lhs_particle = self.nuclei
+        self.assertEqual(self.default3.lhs_particle, self.nuclei)
 
         # # Should not be able to set incompatible particle types
         with self.assertRaises(TypeError):
@@ -99,27 +86,27 @@ class TestExchangeCorrelation(unittest.TestCase):
             self.default1.rhs_particle = self.many_elec
 
     def test_comparison(self):
+        self.assertTrue(self.default1 == CoulombElectronDensityElectron())
         self.assertTrue(
-            self.default1 == ExchangeCorrelationElectronDensityElectron()
+            self.default2 == CoulombManyElectronsDecomposableDensityElectron()
         )
-        self.assertTrue(
-            self.default2
-            == ExchangeCorrelationManyElectronsDecomposableDensityElectron()
-        )
+        self.assertTrue(self.default3 == CoulombNucleiNuclei())
 
         self.assertTrue(
             self.has_value1
-            == ExchangeCorrelationElectronDensityElectron(
-                self.xc, Electron(), self.density
-            )
+            == CoulombElectronDensityElectron(Electron(), self.density)
         )
         self.assertTrue(
             self.has_value2
-            == ExchangeCorrelationManyElectronsDecomposableDensityElectron(
-                self.xc, self.many_elec, self.decomp_density
+            == CoulombManyElectronsDecomposableDensityElectron(
+                self.many_elec, self.decomp_density
             )
+        )
+        self.assertTrue(
+            self.has_value3 == CoulombNucleiNuclei(self.nuclei, self.nuclei)
         )
 
         self.assertFalse(self.default1 == self.default2)
         self.assertFalse(self.default1 == self.has_value1)
         self.assertFalse(self.default2 == self.has_value2)
+        self.assertFalse(self.default3 == self.has_value3)

--- a/tests/python/unit_tests/quantum_mechanics/operators/test_exchange.py
+++ b/tests/python/unit_tests/quantum_mechanics/operators/test_exchange.py
@@ -16,9 +16,8 @@ import unittest
 
 import numpy as np
 from chemist.qm_operator import (
-    ExchangeCorrelationElectronDensityElectron,
-    ExchangeCorrelationManyElectronsDecomposableDensityElectron,
-    xc_functional,
+    ExchangeElectronDensityElectron,
+    ExchangeManyElectronsDecomposableDensityElectron,
 )
 from chemist.wavefunction import AOs
 from tensorwrapper import Tensor
@@ -27,21 +26,7 @@ from chemist import DecomposableDensity, Density, Electron, ManyElectrons
 from chemist.basis_set import AOBasisSetD
 
 
-class TestXCFunctional(unittest.TestCase):
-    def setUp(self):
-        self.none = xc_functional.NONE
-        self.custom = xc_functional.CUSTOM
-
-    def test_functional_name(self):
-        self.assertEqual(self.none.name, "NONE")
-        self.assertEqual(self.custom.name, "CUSTOM")
-
-    def test_functional_value(self):
-        self.assertEqual(self.none.value, 0)
-        self.assertEqual(self.custom.value, 1)
-
-
-class TestExchangeCorrelation(unittest.TestCase):
+class TestExchange(unittest.TestCase):
     def setUp(self):
         # Input Values
         self.many_elec = ManyElectrons(4)
@@ -52,31 +37,16 @@ class TestExchangeCorrelation(unittest.TestCase):
         self.decomp_density = DecomposableDensity(
             self.tensor, self.aos, self.tensor
         )
-        self.xc = xc_functional.PBE
 
         # Test objects
-        self.default1 = ExchangeCorrelationElectronDensityElectron()
-        self.default2 = (
-            ExchangeCorrelationManyElectronsDecomposableDensityElectron()
+        self.default1 = ExchangeElectronDensityElectron()
+        self.default2 = ExchangeManyElectronsDecomposableDensityElectron()
+        self.has_value1 = ExchangeElectronDensityElectron(
+            Electron(), self.density
         )
-        self.has_value1 = ExchangeCorrelationElectronDensityElectron(
-            self.xc, Electron(), self.density
+        self.has_value2 = ExchangeManyElectronsDecomposableDensityElectron(
+            self.many_elec, self.decomp_density
         )
-        self.has_value2 = (
-            ExchangeCorrelationManyElectronsDecomposableDensityElectron(
-                self.xc, self.many_elec, self.decomp_density
-            )
-        )
-
-    def test_functional_name(self):
-        self.assertEqual(self.default1.functional_name, xc_functional.NONE)
-        self.assertEqual(self.default2.functional_name, xc_functional.NONE)
-        self.assertEqual(self.has_value1.functional_name, self.xc)
-        self.assertEqual(self.has_value2.functional_name, self.xc)
-
-        # Check for writing
-        self.default1.functional_name = self.xc
-        self.assertEqual(self.default1.functional_name, self.xc)
 
     def test_particles(self):
         self.assertEqual(self.default1.lhs_particle, Electron())
@@ -99,24 +69,19 @@ class TestExchangeCorrelation(unittest.TestCase):
             self.default1.rhs_particle = self.many_elec
 
     def test_comparison(self):
+        self.assertTrue(self.default1 == ExchangeElectronDensityElectron())
         self.assertTrue(
-            self.default1 == ExchangeCorrelationElectronDensityElectron()
-        )
-        self.assertTrue(
-            self.default2
-            == ExchangeCorrelationManyElectronsDecomposableDensityElectron()
+            self.default2 == ExchangeManyElectronsDecomposableDensityElectron()
         )
 
         self.assertTrue(
             self.has_value1
-            == ExchangeCorrelationElectronDensityElectron(
-                self.xc, Electron(), self.density
-            )
+            == ExchangeElectronDensityElectron(Electron(), self.density)
         )
         self.assertTrue(
             self.has_value2
-            == ExchangeCorrelationManyElectronsDecomposableDensityElectron(
-                self.xc, self.many_elec, self.decomp_density
+            == ExchangeManyElectronsDecomposableDensityElectron(
+                self.many_elec, self.decomp_density
             )
         )
 

--- a/tests/python/unit_tests/quantum_mechanics/operators/test_exchange_correlation.py
+++ b/tests/python/unit_tests/quantum_mechanics/operators/test_exchange_correlation.py
@@ -1,0 +1,31 @@
+# Copyright 2026 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from chemist.qm_operator import xc_functional
+
+
+class TestExchangeCorrelation(unittest.TestCase):
+    def setUp(self):
+        self.none = xc_functional.NONE
+        self.custom = xc_functional.CUSTOM
+
+    def test_functional_name(self):
+        self.assertEqual(self.none.name, "NONE")
+        self.assertEqual(self.custom.name, "CUSTOM")
+
+    def test_functional_value(self):
+        self.assertEqual(self.none.value, 0)
+        self.assertEqual(self.custom.value, 1)

--- a/tests/python/unit_tests/quantum_mechanics/operators/test_identity.py
+++ b/tests/python/unit_tests/quantum_mechanics/operators/test_identity.py
@@ -1,0 +1,27 @@
+# Copyright 2026 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from chemist.qm_operator import Identity
+
+
+class TestIdentity(unittest.TestCase):
+    def setUp(self):
+        self.identity = Identity()
+
+    def test_comparison(self):
+        # Identity is always equal to Identity
+        self.assertTrue(self.identity == Identity())
+        self.assertFalse(self.identity != Identity())

--- a/tests/python/unit_tests/quantum_mechanics/operators/test_kinetic.py
+++ b/tests/python/unit_tests/quantum_mechanics/operators/test_kinetic.py
@@ -1,0 +1,50 @@
+# Copyright 2026 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from chemist.qm_operator import KineticElectron, KineticManyElectrons
+
+from chemist import Electron, ManyElectrons
+
+
+class TestKinetic(unittest.TestCase):
+    def setUp(self):
+        self.many_elec = ManyElectrons(4)
+        self.kinetic_elec = KineticElectron()
+        self.kinetic_many1 = KineticManyElectrons()
+        self.kinetic_many2 = KineticManyElectrons(self.many_elec)
+
+    def test_particle(self):
+        self.assertEqual(self.kinetic_elec.particle, Electron())
+        self.assertEqual(self.kinetic_many1.particle, ManyElectrons())
+        self.assertEqual(self.kinetic_many2.particle, self.many_elec)
+
+        # Check for writing
+        self.kinetic_many1.particle = self.many_elec
+        self.assertEqual(self.kinetic_many1.particle, self.many_elec)
+
+        # Should not be able to set incompatible particle types
+        with self.assertRaises(TypeError):
+            self.kinetic_elec.particle = self.many_elec
+
+    def test_comparison(self):
+        self.assertTrue(self.kinetic_elec == KineticElectron())
+        self.assertTrue(self.kinetic_many1 == KineticManyElectrons())
+        self.assertTrue(
+            self.kinetic_many2 == KineticManyElectrons(self.many_elec)
+        )
+
+        self.assertFalse(self.kinetic_elec == self.kinetic_many1)
+        self.assertFalse(self.kinetic_many1 == self.kinetic_many2)


### PR DESCRIPTION
**Description**
Exposes the QM operators to Python. Required refactor of the the operators to have explicit getter/setter methods with particle members, and also exposing several "`ViewOfThing<const Thing>`" classes to Python.
