### PR TITLE
Mass formatting and consistency improvement

### DIFF
--- a/include/chemist/basis_set/ao_basis_set.hpp
+++ b/include/chemist/basis_set/ao_basis_set.hpp
@@ -21,6 +21,7 @@
 #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist::basis_set {
+
 namespace detail_ {
 template<typename AtomicBasisSetType>
 class AOBasisSetPIMPL;

--- a/include/chemist/basis_set/atomic_basis_set.hpp
+++ b/include/chemist/basis_set/atomic_basis_set.hpp
@@ -20,10 +20,11 @@
 #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist::basis_set {
+
 namespace detail_ {
 template<typename ShellType>
 class AtomicBasisSetPIMPL;
-}
+} // namespace detail_
 
 /** @brief Models a set of shells associated with a specific atomic center.
  *

--- a/include/chemist/basis_set/atomic_basis_set_view.hpp
+++ b/include/chemist/basis_set/atomic_basis_set_view.hpp
@@ -20,10 +20,11 @@
 #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist::basis_set {
+
 namespace detail_ {
 template<typename AtomicBasisSetType>
 class AtomicBasisSetViewPIMPL;
-}
+} // namespace detail_
 
 /** @brief Behaves like a reference to an AtomicBasisSet.
  *

--- a/include/chemist/basis_set/contracted_gaussian.hpp
+++ b/include/chemist/basis_set/contracted_gaussian.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 namespace chemist::basis_set {
+
 namespace detail_ {
 template<typename PrimitiveType>
 class ContractedGaussianPIMPL;

--- a/include/chemist/basis_set/contracted_gaussian_view.hpp
+++ b/include/chemist/basis_set/contracted_gaussian_view.hpp
@@ -19,10 +19,11 @@
 #include <chemist/detail_/view_traits.hpp>
 
 namespace chemist::basis_set {
+
 namespace detail_ {
 template<typename CGType>
 class ContractedGaussianViewPIMPL;
-}
+} // namespace detail_
 
 /** @brief Models a reference to a ContractedGaussian
  *

--- a/include/chemist/basis_set/primitive.hpp
+++ b/include/chemist/basis_set/primitive.hpp
@@ -21,10 +21,11 @@
 #include <vector>
 
 namespace chemist::basis_set {
+
 namespace detail_ {
 template<typename T>
 struct PrimitivePIMPL;
-}
+} // namespace detail_
 
 /** @brief Models a Gaussian Primitive by value.
  *

--- a/include/chemist/basis_set/shell.hpp
+++ b/include/chemist/basis_set/shell.hpp
@@ -23,6 +23,7 @@
 // #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist::basis_set {
+
 namespace detail_ {
 template<typename CGType>
 class ShellPIMPL;

--- a/include/chemist/basis_set/shell_view.hpp
+++ b/include/chemist/basis_set/shell_view.hpp
@@ -20,6 +20,7 @@
 #include <chemist/detail_/view_traits.hpp>
 
 namespace chemist::basis_set {
+
 namespace detail_ {
 template<typename ShellType>
 class ShellViewPIMPL;

--- a/include/chemist/chemical_system/chemical_system_class.hpp
+++ b/include/chemist/chemical_system/chemical_system_class.hpp
@@ -20,9 +20,10 @@
 #include <memory>
 
 namespace chemist {
+
 namespace detail_ {
 class ChemicalSystemPIMPL;
-}
+} // namespace detail_
 
 /** @brief Class describing the entire chemical system to be modeled.
  *

--- a/include/chemist/chemical_system/chemical_system_view.hpp
+++ b/include/chemist/chemical_system/chemical_system_view.hpp
@@ -16,11 +16,13 @@
 
 #pragma once
 #include <chemist/chemical_system/chemical_system_class.hpp>
+
 namespace chemist {
+
 namespace detail_ {
 template<typename ChemicalSystemType>
 class ChemicalSystemViewPIMPL;
-}
+} // namespace detail_
 
 /** @brief Enables using existing state as if it were a ChemicalSystem.
  *

--- a/include/chemist/fragmenting/fragmented_chemical_system.hpp
+++ b/include/chemist/fragmenting/fragmented_chemical_system.hpp
@@ -21,11 +21,11 @@
 #include <chemist/traits/fragmenting_traits.hpp>
 
 namespace chemist::fragmenting {
+
 namespace detail_ {
 template<typename ChemicalSystemType>
 class FragmentedChemicalSystemPIMPL;
-
-}
+} // namespace detail_
 
 /** @brief Stores fragments of a ChemicalSystem object.
  *

--- a/include/chemist/fragmenting/fragmented_molecule.hpp
+++ b/include/chemist/fragmenting/fragmented_molecule.hpp
@@ -21,11 +21,11 @@
 #include <chemist/traits/fragmenting_traits.hpp>
 
 namespace chemist::fragmenting {
+
 namespace detail_ {
 template<typename MoleculeType>
 class FragmentedMoleculePIMPL;
-
-}
+} // namespace detail_
 
 /** @brief Stores pieces of a Molecule object.
  *

--- a/include/chemist/fragmenting/fragmented_nuclei.hpp
+++ b/include/chemist/fragmenting/fragmented_nuclei.hpp
@@ -20,10 +20,11 @@
 #include <chemist/nucleus/nucleus.hpp>
 
 namespace chemist::fragmenting {
+
 namespace detail_ {
 template<typename NucleiType>
 class FragmentedNucleiPIMPL;
-}
+} // namespace detail_
 
 /** @brief Represents a set of fragments derived from a Nuclei object.
  *

--- a/include/chemist/molecule/molecule_class.hpp
+++ b/include/chemist/molecule/molecule_class.hpp
@@ -22,6 +22,7 @@
 #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 /// Forward declaration of class that holds the molecule's implementation
 class MoleculePIMPL;

--- a/include/chemist/molecule/molecule_view.hpp
+++ b/include/chemist/molecule/molecule_view.hpp
@@ -21,11 +21,11 @@
 #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 template<typename MoleculeType>
 class MoleculeViewPIMPL;
-
-}
+} // namespace detail_
 
 /** @brief Allows existing molecular state to be used as if it were a Molecule
  *         object.

--- a/include/chemist/nucleus/nuclei.hpp
+++ b/include/chemist/nucleus/nuclei.hpp
@@ -21,6 +21,7 @@
 #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 class NucleiPIMPL;
 } // namespace detail_

--- a/include/chemist/nucleus/nuclei_view.hpp
+++ b/include/chemist/nucleus/nuclei_view.hpp
@@ -21,10 +21,10 @@
 #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 template<typename NucleiType>
 class NucleiViewPIMPL;
-
 } // namespace detail_
 
 /** @brief Allows existing state to be used as if it were a Nuclei object.

--- a/include/chemist/point/point_class.hpp
+++ b/include/chemist/point/point_class.hpp
@@ -20,10 +20,11 @@
 #include <memory>
 
 namespace chemist {
+
 namespace detail_ {
 template<typename T>
 class PointPIMPL;
-}
+} // namespace detail_
 
 /** @brief An object that is associated with a point in 3-D Cartesian space.
  *

--- a/include/chemist/point/point_set.hpp
+++ b/include/chemist/point/point_set.hpp
@@ -21,10 +21,11 @@
 #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 template<typename T>
 class PointSetPIMPL;
-}
+} // namespace detail_
 
 /** @brief A container filled with Point objects
  *

--- a/include/chemist/point/point_set_view.hpp
+++ b/include/chemist/point/point_set_view.hpp
@@ -22,10 +22,11 @@
 #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 template<typename PointSetType>
 class PointSetViewPIMPL;
-}
+} // namespace detail_
 
 /** @brief Acts like a reference to a PointSet object.
  *

--- a/include/chemist/point_charge/charges.hpp
+++ b/include/chemist/point_charge/charges.hpp
@@ -22,10 +22,11 @@
 #include <vector>
 
 namespace chemist {
+
 namespace detail_ {
 template<typename T>
 class ChargesPIMPL;
-}
+} // namespace detail_
 
 /** @brief Represents a container of PointCharge objects.
  *

--- a/include/chemist/point_charge/charges_view.hpp
+++ b/include/chemist/point_charge/charges_view.hpp
@@ -20,10 +20,11 @@
 #include <utilities/containers/indexable_container_base.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 template<typename ChargesType>
 class ChargesViewPIMPL;
-}
+} // namespace detail_
 
 /** @brief Enables treating state like it's a reference to a Charges object.
  *

--- a/include/chemist/quantum_mechanics/braket/braket_class.hpp
+++ b/include/chemist/quantum_mechanics/braket/braket_class.hpp
@@ -20,6 +20,7 @@
 #include <chemist/traits/quantum_mechanics_traits.hpp>
 
 namespace chemist::braket {
+
 namespace detail_ {
 
 /** @brief Works out the base class for a given instantiation of BraKet.

--- a/include/chemist/topology/connectivity_table.hpp
+++ b/include/chemist/topology/connectivity_table.hpp
@@ -18,9 +18,10 @@
 #include <chemist/traits/topology.hpp>
 
 namespace chemist::topology {
+
 namespace detail_ {
 class ConnectivityTablePIMPL;
-}
+} // namespace detail_
 
 /** @brief Stores the a list of bonds in a molecule.
  *

--- a/include/chemist/traits/fragmenting_traits.hpp
+++ b/include/chemist/traits/fragmenting_traits.hpp
@@ -21,6 +21,7 @@
 #include <chemist/traits/nucleus_traits.hpp>
 
 namespace chemist {
+
 namespace fragmenting {
 class CapSet;
 template<typename DerivedType>

--- a/include/chemist/traits/grid_traits.hpp
+++ b/include/chemist/traits/grid_traits.hpp
@@ -19,6 +19,7 @@
 #include <chemist/traits/point_traits.hpp>
 
 namespace chemist {
+
 class GridPoint;
 template<typename GridPointType>
 class GridPointView;

--- a/include/chemist/traits/molecule_traits.hpp
+++ b/include/chemist/traits/molecule_traits.hpp
@@ -21,6 +21,7 @@
 #include <chemist/traits/nucleus_traits.hpp>
 
 namespace chemist {
+
 class Atom;
 template<typename AtomType>
 class AtomView;

--- a/include/chemist/traits/nucleus_traits.hpp
+++ b/include/chemist/traits/nucleus_traits.hpp
@@ -20,6 +20,7 @@
 #include <string>
 
 namespace chemist {
+
 class Nucleus;
 template<typename T>
 class NucleusView;

--- a/include/chemist/traits/point_charge_traits.hpp
+++ b/include/chemist/traits/point_charge_traits.hpp
@@ -19,6 +19,7 @@
 #include <chemist/traits/point_traits.hpp>
 
 namespace chemist {
+
 template<typename T>
 class PointCharge;
 template<typename T>

--- a/include/chemist/traits/point_traits.hpp
+++ b/include/chemist/traits/point_traits.hpp
@@ -18,6 +18,7 @@
 #include <chemist/traits/chemist_class_traits.hpp>
 
 namespace chemist {
+
 template<typename T>
 class Point;
 template<typename PointType>

--- a/include/chemist/traits/quantum_mechanics_traits.hpp
+++ b/include/chemist/traits/quantum_mechanics_traits.hpp
@@ -18,9 +18,10 @@
 #include <type_traits>
 
 namespace chemist {
+
 namespace qm_operator {
 class OperatorBase;
-}
+} // namespace qm_operator
 
 namespace wavefunction {
 class Wavefunction;

--- a/include/chemist/traits/topology.hpp
+++ b/include/chemist/traits/topology.hpp
@@ -22,6 +22,7 @@
 #include <set>
 #include <vector>
 namespace chemist {
+
 namespace topology {
 class ConnectivityTable;
 } // namespace topology

--- a/src/chemist/fragmenting/fragmented_chemical_system.cpp
+++ b/src/chemist/fragmenting/fragmented_chemical_system.cpp
@@ -17,6 +17,7 @@
 #include <chemist/fragmenting/fragmented_chemical_system.hpp>
 
 namespace chemist::fragmenting {
+
 namespace detail_ {
 
 template<typename ChemicalSystemType>

--- a/src/chemist/fragmenting/fragmented_molecule.cpp
+++ b/src/chemist/fragmenting/fragmented_molecule.cpp
@@ -17,6 +17,7 @@
 #include <chemist/fragmenting/fragmented_molecule.hpp>
 
 namespace chemist::fragmenting {
+
 namespace detail_ {
 
 template<typename MoleculeType>

--- a/src/chemist/fragmenting/fragmented_nuclei.cpp
+++ b/src/chemist/fragmenting/fragmented_nuclei.cpp
@@ -17,8 +17,8 @@
 #include <chemist/fragmenting/fragmented_nuclei.hpp>
 
 namespace chemist::fragmenting {
+
 namespace detail_ {
-namespace {} // namespace
 
 template<typename NucleiType>
 class FragmentedNucleiPIMPL {

--- a/src/chemist/molecule/detail_/molecule_view_pimpl.hpp
+++ b/src/chemist/molecule/detail_/molecule_view_pimpl.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <chemist/molecule/molecule_view.hpp>
+
 namespace chemist::detail_ {
 
 template<typename MoleculeType>

--- a/src/python/basis_set/export_ao_basis_set.cpp
+++ b/src/python/basis_set/export_ao_basis_set.cpp
@@ -16,9 +16,9 @@
 
 #include "export_basis_set.hpp"
 #include <chemist/basis_set/ao_basis_set.hpp>
-#include <pybind11/stl.h>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -31,7 +31,7 @@ void export_ao_basis_set_(const char* name, python_module_reference m) {
     using size_type      = typename abs_type::size_type;
 
     python_class_type<aobs_type>(m, name)
-      .def(pybind11::init<>())
+      .def(py::init<>())
       .def("add_center", [](aobs_type& s, abs_type b) { s.add_center(b); })
       .def("shell_range",
            [](aobs_type& s, size_type i) { return s.shell_range(i); })
@@ -47,10 +47,10 @@ void export_ao_basis_set_(const char* name, python_module_reference m) {
       .def("empty", [](aobs_type& s) { return s.empty(); })
       .def("at", [](aobs_type& s, size_type i) { return s[i]; })
       .def("size", [](aobs_type& s) { return s.size(); })
-      .def(pybind11::self + pybind11::self)
-      .def(pybind11::self += pybind11::self)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self + py::self)
+      .def(py::self += py::self)
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace detail_

--- a/src/python/basis_set/export_atomic_basis_set.cpp
+++ b/src/python/basis_set/export_atomic_basis_set.cpp
@@ -16,9 +16,9 @@
 
 #include "export_basis_set.hpp"
 #include <chemist/basis_set/atomic_basis_set.hpp>
-#include <pybind11/stl.h>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -36,18 +36,18 @@ void export_atomic_basis_set_(const char* name, python_module_reference m) {
     using atomic_number_type    = typename abs_type::atomic_number_type;
 
     python_class_type<abs_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<name_type, atomic_number_type, coord_type, coord_type,
-                          coord_type>())
-      .def(pybind11::init<name_type, atomic_number_type, center_type>())
-      .def(pybind11::init<coord_type, coord_type, coord_type>())
-      .def(pybind11::init<center_type>())
-      .def(pybind11::init<name_type, atomic_number_type>())
-      .def(pybind11::init([](center_type r, std::vector<shell_type> ss) {
+      .def(py::init<>())
+      .def(py::init<name_type, atomic_number_type, coord_type, coord_type,
+                    coord_type>())
+      .def(py::init<name_type, atomic_number_type, center_type>())
+      .def(py::init<coord_type, coord_type, coord_type>())
+      .def(py::init<center_type>())
+      .def(py::init<name_type, atomic_number_type>())
+      .def(py::init([](center_type r, std::vector<shell_type> ss) {
           return abs_type(r, ss.begin(), ss.end());
       }))
-      .def(pybind11::init([](name_type n, atomic_number_type z, center_type r,
-                             std::vector<shell_type> ss) {
+      .def(py::init([](name_type n, atomic_number_type z, center_type r,
+                       std::vector<shell_type> ss) {
           return abs_type(n, z, r, ss.begin(), ss.end());
       }))
       .def_property(
@@ -72,8 +72,8 @@ void export_atomic_basis_set_(const char* name, python_module_reference m) {
       .def("at", [](abs_type& s, size_type i) { return s[i]; })
       .def("size", [](abs_type& s) { return s.size(); })
       .def("is_null", [](abs_type& s) { return s.is_null(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace detail_

--- a/src/python/basis_set/export_atomic_basis_set_view.cpp
+++ b/src/python/basis_set/export_atomic_basis_set_view.cpp
@@ -16,9 +16,9 @@
 
 #include "export_basis_set.hpp"
 #include <chemist/basis_set/atomic_basis_set_view.hpp>
-#include <pybind11/stl.h>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -34,8 +34,8 @@ void export_abs_view_(const char* name, python_module_reference m) {
     using atomic_number_type = typename abs_type::atomic_number_type;
 
     python_class_type<abs_view_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<abs_type&>())
+      .def(py::init<>())
+      .def(py::init<abs_type&>())
       .def_property(
         "basis_set_name", [](abs_view_type& s) { return s.basis_set_name(); },
         [](abs_view_type& s, name_type n) { s.basis_set_name() = n; })
@@ -58,12 +58,12 @@ void export_abs_view_(const char* name, python_module_reference m) {
       .def("at", [](abs_view_type& s, size_type i) { return s[i]; })
       .def("size", [](abs_view_type& s) { return s.size(); })
       .def("is_null", [](abs_view_type& s) { return s.is_null(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == abs_type())
-      .def(abs_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != abs_type())
-      .def(abs_type() != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self == abs_type())
+      .def(abs_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != abs_type())
+      .def(abs_type() != py::self);
 }
 
 } // namespace detail_

--- a/src/python/basis_set/export_basis_set.hpp
+++ b/src/python/basis_set/export_basis_set.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 #include "../pychemist.hpp"
-#include <pybind11/operators.h>
 
 namespace chemist {
 

--- a/src/python/basis_set/export_contracted_gaussian.cpp
+++ b/src/python/basis_set/export_contracted_gaussian.cpp
@@ -16,9 +16,9 @@
 
 #include "export_basis_set.hpp"
 #include <chemist/basis_set/contracted_gaussian.hpp>
-#include <pybind11/stl.h>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -31,12 +31,12 @@ void export_contracted_gaussian_(const char* name, python_module_reference m) {
     using vector_type    = std::vector<T>;
 
     python_class_type<cg_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init([](vector_type& cs, vector_type& es, center_type r) {
+      .def(py::init<>())
+      .def(py::init([](vector_type& cs, vector_type& es, center_type r) {
           return cg_type(cs.begin(), cs.end(), es.begin(), es.end(), r);
       }))
-      .def(pybind11::init([](vector_type& cs, vector_type& es, coord_type x,
-                             coord_type y, coord_type z) {
+      .def(py::init([](vector_type& cs, vector_type& es, coord_type x,
+                       coord_type y, coord_type z) {
           return cg_type(cs.begin(), cs.end(), es.begin(), es.end(), x, y, z);
       }))
       .def("empty", [](cg_type& cg) { return cg.empty(); })
@@ -46,8 +46,8 @@ void export_contracted_gaussian_(const char* name, python_module_reference m) {
         "center", [](cg_type& cg) { return cg.center(); },
         [](cg_type& cg, center_type c) { cg.center() = c; })
       .def("is_null", [](cg_type& cg) { return cg.is_null(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace detail_

--- a/src/python/basis_set/export_contracted_gaussian_view.cpp
+++ b/src/python/basis_set/export_contracted_gaussian_view.cpp
@@ -18,6 +18,7 @@
 #include <chemist/basis_set/contracted_gaussian_view.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -29,8 +30,8 @@ void export_cg_view_(const char* name, python_module_reference m) {
     using size_type      = typename cg_type::size_type;
 
     python_class_type<cg_view_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<cg_type&>())
+      .def(py::init<>())
+      .def(py::init<cg_type&>())
       .def("empty", [](cg_view_type& cg) { return cg.empty(); })
       .def("at", [](cg_view_type& cg, size_type i) { return cg[i]; })
       .def("size", [](cg_view_type& cg) { return cg.size(); })
@@ -38,12 +39,12 @@ void export_cg_view_(const char* name, python_module_reference m) {
         "center", [](cg_view_type& cg) { return cg.center(); },
         [](cg_view_type& cg, center_type c) { cg.center() = c; })
       .def("is_null", [](cg_view_type& cg) { return cg.is_null(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == cg_type())
-      .def(cg_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != cg_type())
-      .def(cg_type() != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self == cg_type())
+      .def(cg_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != cg_type())
+      .def(cg_type() != py::self);
 }
 
 } // namespace detail_

--- a/src/python/basis_set/export_primitive.cpp
+++ b/src/python/basis_set/export_primitive.cpp
@@ -18,6 +18,7 @@
 #include <chemist/basis_set/primitive.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -29,10 +30,10 @@ void export_primitive_(const char* name, python_module_reference m) {
     using coord_type     = typename primitive_type::coord_type;
 
     python_class_type<primitive_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<coeff_type, expo_type, coord_type, coord_type,
-                          coord_type>())
-      .def(pybind11::init<coeff_type, expo_type, center_type>())
+      .def(py::init<>())
+      .def(
+        py::init<coeff_type, expo_type, coord_type, coord_type, coord_type>())
+      .def(py::init<coeff_type, expo_type, center_type>())
       .def_property(
         "center", [](primitive_type& p) { return p.center(); },
         [](primitive_type& p, center_type c) { p.center() = c; })
@@ -43,8 +44,8 @@ void export_primitive_(const char* name, python_module_reference m) {
         "exponent", [](primitive_type& p) { return p.exponent(); },
         [](primitive_type& p, expo_type e) { p.exponent() = e; })
       .def("is_null", [](primitive_type& p) { return p.is_null(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace detail_

--- a/src/python/basis_set/export_primitive_view.cpp
+++ b/src/python/basis_set/export_primitive_view.cpp
@@ -18,6 +18,7 @@
 #include <chemist/basis_set/primitive_view.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -30,8 +31,8 @@ void export_primitive_view_(const char* name, python_module_reference m) {
     using center_type = typename primitive_view_type::center_type;
 
     python_class_type<primitive_view_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<primitive_type&>())
+      .def(py::init<>())
+      .def(py::init<primitive_type&>())
       .def_property(
         "center", [](primitive_view_type& p) { return p.center(); },
         [](primitive_view_type& p, center_type c) { p.center() = c; })
@@ -42,12 +43,12 @@ void export_primitive_view_(const char* name, python_module_reference m) {
         "exponent", [](primitive_view_type& p) { return p.exponent(); },
         [](primitive_view_type& p, expo_type e) { p.exponent() = e; })
       .def("is_null", [](primitive_view_type& p) { return p.is_null(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == primitive_type())
-      .def(primitive_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != primitive_type())
-      .def(primitive_type() != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self == primitive_type())
+      .def(primitive_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != primitive_type())
+      .def(primitive_type() != py::self);
 }
 
 } // namespace detail_

--- a/src/python/basis_set/export_shell.cpp
+++ b/src/python/basis_set/export_shell.cpp
@@ -16,9 +16,9 @@
 
 #include "export_basis_set.hpp"
 #include <chemist/basis_set/shell.hpp>
-#include <pybind11/stl.h>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -34,19 +34,19 @@ void export_shell_(const char* name, python_module_reference m) {
     using vector_type           = std::vector<T>;
 
     python_class_type<shell_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init([](pure_type pure, angular_momentum_type l,
-                             vector_type& cs, vector_type& es, center_type r) {
+      .def(py::init<>())
+      .def(py::init([](pure_type pure, angular_momentum_type l, vector_type& cs,
+                       vector_type& es, center_type r) {
           return shell_type(pure, l, cs.begin(), cs.end(), es.begin(), es.end(),
                             r);
       }))
-      .def(pybind11::init([](pure_type pure, angular_momentum_type l,
-                             vector_type& cs, vector_type& es, coord_type x,
-                             coord_type y, coord_type z) {
-          return shell_type(pure, l, cs.begin(), cs.end(), es.begin(), es.end(),
-                            x, y, z);
-      }))
-      .def(pybind11::init<pure_type, angular_momentum_type, cg_type>())
+      .def(
+        py::init([](pure_type pure, angular_momentum_type l, vector_type& cs,
+                    vector_type& es, coord_type x, coord_type y, coord_type z) {
+            return shell_type(pure, l, cs.begin(), cs.end(), es.begin(),
+                              es.end(), x, y, z);
+        }))
+      .def(py::init<pure_type, angular_momentum_type, cg_type>())
       .def_property(
         "pure", [](shell_type& s) { return s.pure(); },
         [](shell_type& s, pure_type p) { s.pure() = p; })
@@ -65,8 +65,8 @@ void export_shell_(const char* name, python_module_reference m) {
            [](shell_type& s, size_type i) { return s.primitive(i); })
       .def("size", [](shell_type& s) { return s.size(); })
       .def("is_null", [](shell_type& s) { return s.is_null(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace detail_

--- a/src/python/basis_set/export_shell_view.cpp
+++ b/src/python/basis_set/export_shell_view.cpp
@@ -18,6 +18,7 @@
 #include <chemist/basis_set/shell_view.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -32,8 +33,8 @@ void export_shell_view_(const char* name, python_module_reference m) {
     using center_type           = typename primitive_type::center_type;
 
     python_class_type<shell_view_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<shell_type&>())
+      .def(py::init<>())
+      .def(py::init<shell_type&>())
       .def_property(
         "pure", [](shell_view_type& s) { return s.pure(); },
         [](shell_view_type& s, pure_type p) { s.pure() = p; })
@@ -52,12 +53,12 @@ void export_shell_view_(const char* name, python_module_reference m) {
            [](shell_view_type& s, size_type i) { return s.primitive(i); })
       .def("size", [](shell_view_type& s) { return s.size(); })
       .def("is_null", [](shell_view_type& s) { return s.is_null(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == shell_type())
-      .def(shell_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != shell_type())
-      .def(shell_type() != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self == shell_type())
+      .def(shell_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != shell_type())
+      .def(shell_type() != py::self);
 }
 
 } // namespace detail_

--- a/src/python/chemical_system/export_chemical_system_class.cpp
+++ b/src/python/chemical_system/export_chemical_system_class.cpp
@@ -16,7 +16,6 @@
 
 #include "export_chemical_system.hpp"
 #include <chemist/chemical_system/chemical_system.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
 
@@ -26,16 +25,16 @@ void export_chemical_system_class(python_module_reference m) {
     using molecule_type             = typename chemical_system_type::molecule_t;
 
     python_class_type<ChemicalSystem>(m, "ChemicalSystem")
-      .def(pybind11::init<>())
-      .def(pybind11::init<molecule_type>())
+      .def(py::init<>())
+      .def(py::init<molecule_type>())
       .def_property(
         "molecule",
         [](chemical_system_reference self) { return self.molecule(); },
         [](chemical_system_reference self, molecule_type mol) {
             self.molecule() = mol;
         })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/chemical_system/export_chemical_system_view.cpp
+++ b/src/python/chemical_system/export_chemical_system_view.cpp
@@ -15,7 +15,6 @@
  */
 #include "export_chemical_system.hpp"
 #include <chemist/chemical_system/chemical_system_view.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
 
@@ -26,15 +25,15 @@ void export_chemical_system_view(python_module_reference m) {
     using molecule_type        = typename chemical_system_type::molecule_t;
 
     python_class_type<view_type>(m, "ChemicalSystemView")
-      .def(pybind11::init<>())
-      .def(pybind11::init<chemical_system_type&>())
+      .def(py::init<>())
+      .def(py::init<chemical_system_type&>())
       .def_property(
         "molecule", [](reference self) { return self.molecule(); },
         [](reference self, molecule_type mol) { self.molecule() = mol; })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == chemical_system_type{})
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != chemical_system_type{});
+      .def(py::self == py::self)
+      .def(py::self == chemical_system_type{})
+      .def(py::self != py::self)
+      .def(py::self != chemical_system_type{});
 }
 
 } // namespace chemist

--- a/src/python/density/export_decomposable_density.cpp
+++ b/src/python/density/export_decomposable_density.cpp
@@ -16,7 +16,6 @@
 
 #include "export_density.hpp"
 #include <chemist/density/decomposable_density.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
 
@@ -30,14 +29,14 @@ void export_decomposable_density(python_module_reference m) {
 
     python_class_type<decomposable_density_t, density_t>(m,
                                                          "DecomposableDensity")
-      .def(pybind11::init<>())
-      .def(pybind11::init<value_t, transformed_basis_t>())
-      .def(pybind11::init<value_t, basis_t, value_t>())
+      .def(py::init<>())
+      .def(py::init<value_t, transformed_basis_t>())
+      .def(py::init<value_t, basis_t, value_t>())
       .def_property_readonly(
         "left_factor",
         [](decomposable_density_t& d) { return d.left_factor(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/density/export_density_class.cpp
+++ b/src/python/density/export_density_class.cpp
@@ -16,7 +16,6 @@
 
 #include "export_density.hpp"
 #include <chemist/density/density_class.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
 
@@ -35,12 +34,12 @@ void export_density_class(python_module_reference m) {
     python_module_type::import("tensorwrapper");
 
     python_class_type<density_t>(m, "Density")
-      .def(pybind11::init<>())
-      .def(pybind11::init<value_t, basis_t>())
+      .def(py::init<>())
+      .def(py::init<value_t, basis_t>())
       .def_property("value", get_value, set_value)
       .def_property("basis_set", get_basis, set_basis)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/electron/export_electron_class.cpp
+++ b/src/python/electron/export_electron_class.cpp
@@ -16,15 +16,14 @@
 
 #include "export_electron.hpp"
 #include <chemist/electron/electron_class.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
 
 void export_electron_class(python_module_reference m) {
     python_class_type<Electron>(m, "Electron")
-      .def(pybind11::init<>())
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::init<>())
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/electron/export_many_electrons.cpp
+++ b/src/python/electron/export_many_electrons.cpp
@@ -16,7 +16,6 @@
 
 #include "export_electron.hpp"
 #include <chemist/electron/many_electrons.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
 
@@ -24,12 +23,12 @@ void export_many_electrons(python_module_reference m) {
     using size_type = typename ManyElectrons::size_type;
 
     python_class_type<ManyElectrons>(m, "ManyElectrons")
-      .def(pybind11::init<>())
-      .def(pybind11::init<size_type>())
+      .def(py::init<>())
+      .def(py::init<size_type>())
       .def("at", [](ManyElectrons& self, size_type i) { return self.at(i); })
       .def("size", [](ManyElectrons& self) { return self.size(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/fragmenting/capping/export_cap.cpp
+++ b/src/python/fragmenting/capping/export_cap.cpp
@@ -16,7 +16,6 @@
 
 #include "export_capping.hpp"
 #include <chemist/fragmenting/capping/cap.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::fragmenting {
 
@@ -26,15 +25,14 @@ using reference    = Cap::reference;
 using at_fxn       = reference (Cap::*)(size_type);
 
 void export_cap(python_module_reference m) {
-    auto rvp = pybind11::return_value_policy::reference_internal;
+    auto rvp = py::return_value_policy::reference_internal;
 
     python_class_type<Cap>(m, "Cap")
-      .def(pybind11::init<>())
-      .def(pybind11::init(
-        [](size_type anchor, size_type replaced, pybind11::args args) {
-            auto buffer = args_to_buffer<nucleus_type>(std::move(args));
-            return Cap(anchor, replaced, buffer.begin(), buffer.end());
-        }))
+      .def(py::init<>())
+      .def(py::init([](size_type anchor, size_type replaced, py::args args) {
+          auto buffer = args_to_buffer<nucleus_type>(std::move(args));
+          return Cap(anchor, replaced, buffer.begin(), buffer.end());
+      }))
       .def("insert", &Cap::insert)
       .def("at", static_cast<at_fxn>(&Cap::at), rvp)
       .def("__getitem__", static_cast<at_fxn>(&Cap::at), rvp)
@@ -60,8 +58,8 @@ void export_cap(python_module_reference m) {
                    throw std::runtime_error("No Replacement Set");
                }
            })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist::fragmenting

--- a/src/python/fragmenting/capping/export_cap_set.cpp
+++ b/src/python/fragmenting/capping/export_cap_set.cpp
@@ -16,7 +16,6 @@
 
 #include "export_capping.hpp"
 #include <chemist/fragmenting/capping/cap_set.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::fragmenting {
 
@@ -27,30 +26,30 @@ using reference    = CapSet::reference;
 using at_fxn       = reference (CapSet::*)(size_type);
 
 void export_cap_set(python_module_reference m) {
-    auto rvp = pybind11::return_value_policy::reference_internal;
+    auto rvp = py::return_value_policy::reference_internal;
 
     python_class_type<CapSet>(m, "CapSet")
-      .def(pybind11::init<>())
-      .def(pybind11::init([](pybind11::args args) {
+      .def(py::init<>())
+      .def(py::init([](py::args args) {
           auto buffer = args_to_buffer<cap_type>(std::move(args));
           return CapSet(buffer.begin(), buffer.end());
       }))
       .def("push_back", &CapSet::push_back)
-      .def("emplace_back",
-           [](CapSet& self, size_type anchor, size_type replaced,
-              pybind11::args args) {
-               auto buffer = args_to_buffer<nucleus_type>(std::move(args));
-               self.push_back(
-                 cap_type(anchor, replaced, buffer.begin(), buffer.end()));
-           })
+      .def(
+        "emplace_back",
+        [](CapSet& self, size_type anchor, size_type replaced, py::args args) {
+            auto buffer = args_to_buffer<nucleus_type>(std::move(args));
+            self.push_back(
+              cap_type(anchor, replaced, buffer.begin(), buffer.end()));
+        })
       .def("at", static_cast<at_fxn>(&CapSet::at), rvp)
       .def("__getitem__", static_cast<at_fxn>(&CapSet::at), rvp)
       .def("__setitem__",
            [](CapSet& self, size_type i, cap_type cap) { self.at(i) = cap; })
       .def("size", [](CapSet& self) { return self.size(); })
       .def("__len__", [](CapSet& self) { return self.size(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist::fragmenting

--- a/src/python/fragmenting/export_fragmented_chemical_system.cpp
+++ b/src/python/fragmenting/export_fragmented_chemical_system.cpp
@@ -16,7 +16,6 @@
 
 #include "export_fragmenting.hpp"
 #include <chemist/fragmenting/fragmented_chemical_system.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::fragmenting {
 
@@ -30,21 +29,21 @@ void export_fragmented_chemical_system(python_module_reference m) {
     auto supersystem = [](reference self) { return self.supersystem(); };
     auto at_fxn      = [](reference self, size_type i) { return self.at(i); };
     auto iter_fxn    = [](reference self) {
-        return pybind11::make_iterator(self.begin(), self.end());
+        return py::make_iterator(self.begin(), self.end());
     };
 
-    pybind11::keep_alive<0, 1> ka;
+    py::keep_alive<0, 1> ka;
 
     python_class_type<fragmented_chemical_system>(m, "FragmentedChemicalSystem")
-      .def(pybind11::init<>())
-      .def(pybind11::init<fragmented_molecule_type>())
+      .def(py::init<>())
+      .def(py::init<fragmented_molecule_type>())
       .def("supersystem", supersystem, ka)
       .def("empty", [](reference self) { return self.empty(); })
       .def("at", at_fxn, ka)
       .def("size", [](reference self) { return self.size(); })
       .def("__iter__", iter_fxn, ka)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist::fragmenting

--- a/src/python/fragmenting/export_fragmented_molecule.cpp
+++ b/src/python/fragmenting/export_fragmented_molecule.cpp
@@ -16,7 +16,6 @@
 
 #include "export_fragmenting.hpp"
 #include <chemist/fragmenting/fragmented_molecule.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::fragmenting {
 
@@ -32,12 +31,11 @@ void export_fragmented_molecule(python_module_reference m) {
     using multiplicity_type =
       typename fragmented_molecule_type::multiplicity_type;
 
-    pybind11::keep_alive<0, 1> ka;
+    py::keep_alive<0, 1> ka;
 
     auto value_ctor = [](fragmented_nuclei_type nuclear_frags,
                          charge_type charge, multiplicity_type multiplicity,
-                         pybind11::list py_charges,
-                         pybind11::list py_multiplicities) {
+                         py::list py_charges, py::list py_multiplicities) {
         auto charges = pybind_to_buffer<charge_type>(py_charges);
         auto multiplicities =
           pybind_to_buffer<multiplicity_type>(py_multiplicities);
@@ -49,22 +47,21 @@ void export_fragmented_molecule(python_module_reference m) {
     auto supersystem = [](reference self) { return self.supersystem(); };
     auto at_fxn      = [](reference self, size_type i) { return self.at(i); };
     auto iter_fxn    = [](reference self) {
-        return pybind11::make_iterator(self.begin(), self.end());
+        return py::make_iterator(self.begin(), self.end());
     };
 
     python_class_type<fragmented_molecule_type>(m, "FragmentedMolecule")
-      .def(pybind11::init<>())
-      .def(pybind11::init<supersystem_type>())
-      .def(pybind11::init<fragmented_nuclei_type, charge_type,
-                          multiplicity_type>())
-      .def(pybind11::init(value_ctor))
+      .def(py::init<>())
+      .def(py::init<supersystem_type>())
+      .def(py::init<fragmented_nuclei_type, charge_type, multiplicity_type>())
+      .def(py::init(value_ctor))
       .def("supersystem", supersystem, ka)
       .def("empty", [](reference self) { return self.empty(); })
       .def("at", at_fxn, ka)
       .def("size", [](reference self) { return self.size(); })
       .def("__iter__", iter_fxn, ka)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist::fragmenting

--- a/src/python/fragmenting/export_fragmented_nuclei.cpp
+++ b/src/python/fragmenting/export_fragmented_nuclei.cpp
@@ -16,8 +16,7 @@
 
 #include "export_fragmenting.hpp"
 #include <chemist/fragmenting/fragmented_nuclei.hpp>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
+
 namespace chemist::fragmenting {
 
 void export_fragmented_nuclei(python_module_reference m) {
@@ -32,9 +31,9 @@ void export_fragmented_nuclei(python_module_reference m) {
     using nucleus_type      = typename supersystem_type::value_type;
     using nucleus_reference = typename supersystem_type::reference;
 
-    pybind11::keep_alive<0, 1> ka;
+    py::keep_alive<0, 1> ka;
 
-    auto value_ctor = [](supersystem_type ss, pybind11::list frags,
+    auto value_ctor = [](supersystem_type ss, py::list frags,
                          cap_set_type caps) {
         nucleus_map_type indices;
         for(auto& frag_indices : frags) {
@@ -44,7 +43,7 @@ void export_fragmented_nuclei(python_module_reference m) {
                                       std::move(caps));
     };
 
-    auto insert_index = [](reference self, pybind11::list indices_py) {
+    auto insert_index = [](reference self, py::list indices_py) {
         if(indices_py.size() == 0) {
             self.insert(nucleus_index_set{});
             return;
@@ -66,15 +65,14 @@ void export_fragmented_nuclei(python_module_reference m) {
     auto supersystem = [](reference self) { return self.supersystem(); };
     auto at_fxn      = [](reference self, size_type i) { return self.at(i); };
     auto iter_fxn    = [](reference self) {
-        return pybind11::make_iterator(self.begin(), self.end());
+        return py::make_iterator(self.begin(), self.end());
     };
 
     python_class_type<fragmented_nuclei_type>(m, "FragmentedNuclei")
-      .def(pybind11::init<>())
-      .def(pybind11::init<supersystem_type>())
-      .def(pybind11::init(value_ctor), pybind11::arg("supersystem"),
-           pybind11::arg("nucleus_to_fragment"),
-           pybind11::arg("caps") = cap_set_type{})
+      .def(py::init<>())
+      .def(py::init<supersystem_type>())
+      .def(py::init(value_ctor), py::arg("supersystem"),
+           py::arg("nucleus_to_fragment"), py::arg("caps") = cap_set_type{})
       .def("insert", insert_index)
       .def("nuclear_indices", &fragmented_nuclei_type::nuclear_indices)
       .def("cap_set", cap_set, ka)
@@ -84,8 +82,8 @@ void export_fragmented_nuclei(python_module_reference m) {
       .def("at", at_fxn, ka)
       .def("size", [](reference self) { return self.size(); })
       .def("__iter__", iter_fxn, ka)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist::fragmenting

--- a/src/python/grid/export_grid_class.cpp
+++ b/src/python/grid/export_grid_class.cpp
@@ -16,8 +16,6 @@
 
 #include "export_grid.hpp"
 #include <chemist/grid/grid_class.hpp>
-#include <pybind11/operators.h>
-#include <pybind11/stl.h>
 
 namespace chemist {
 
@@ -28,15 +26,15 @@ void export_grid_class(python_module_reference m) {
     using vector_type = std::vector<value_type>;
 
     python_class_type<grid_type>(m, "Grid")
-      .def(pybind11::init<>())
-      .def(pybind11::init([](vector_type& grid_points) {
+      .def(py::init<>())
+      .def(py::init([](vector_type& grid_points) {
           return grid_type(grid_points.begin(), grid_points.end());
       }))
       .def("empty", [](grid_type& self) { return self.empty(); })
       .def("at", [](grid_type& self, size_type i) { return self[i]; })
       .def("size", [](grid_type& self) { return self.size(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/grid/export_grid_point.cpp
+++ b/src/python/grid/export_grid_point.cpp
@@ -16,7 +16,6 @@
 
 #include "export_grid.hpp"
 #include <chemist/grid/grid_point.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
 
@@ -29,19 +28,19 @@ void export_grid_point(python_module_reference m) {
     using point_reference  = typename gridp_type::point_reference;
 
     python_class_type<gridp_type>(m, "GridPoint")
-      .def(pybind11::init<>())
-      .def(pybind11::init<weight_type, coord_type, coord_type, coord_type>())
-      .def(pybind11::init<weight_type, point_type>())
+      .def(py::init<>())
+      .def(py::init<weight_type, coord_type, coord_type, coord_type>())
+      .def(py::init<weight_type, point_type>())
       .def_property(
         "weight", [](gridp_type& g) -> weight_reference { return g.weight(); },
         [](gridp_type& g, weight_type w) { g.weight() = w; },
-        pybind11::return_value_policy::reference_internal)
+        py::return_value_policy::reference_internal)
       .def_property(
         "point", [](gridp_type& g) -> point_reference { return g.point(); },
         [](gridp_type& g, point_type p) { g.point() = p; },
-        pybind11::return_value_policy::reference_internal)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+        py::return_value_policy::reference_internal)
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/grid/export_grid_point_view.cpp
+++ b/src/python/grid/export_grid_point_view.cpp
@@ -16,7 +16,6 @@
 
 #include "export_grid.hpp"
 #include <chemist/grid/grid_point_view.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
 
@@ -28,21 +27,21 @@ void export_grid_point_view(python_module_reference m) {
     using point_view       = typename gridp_view::point_view;
 
     python_class_type<gridp_view>(m, "GridPointView")
-      .def(pybind11::init<gridp_reference>())
+      .def(py::init<gridp_reference>())
       .def_property(
         "weight", [](gridp_view& g) -> weight_reference { return g.weight(); },
         [](gridp_view& g, weight_reference w) { g.weight() = w; },
-        pybind11::return_value_policy::reference_internal)
+        py::return_value_policy::reference_internal)
       .def_property(
         "point", [](gridp_view& g) -> point_view& { return g.point(); },
         [](gridp_view& g, point_view p) { g.point() = p; },
-        pybind11::return_value_policy::reference_internal)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == gridp_type())
-      .def(gridp_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != gridp_type())
-      .def(gridp_type() != pybind11::self);
+        py::return_value_policy::reference_internal)
+      .def(py::self == py::self)
+      .def(py::self == gridp_type())
+      .def(gridp_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != gridp_type())
+      .def(gridp_type() != py::self);
 }
 
 } // namespace chemist

--- a/src/python/molecule/export_atom.cpp
+++ b/src/python/molecule/export_atom.cpp
@@ -16,7 +16,6 @@
 
 #include "export_molecule.hpp"
 #include <chemist/molecule/atom.hpp>
-#include <pybind11/operators.h>
 #include <sstream>
 
 namespace chemist {
@@ -36,13 +35,13 @@ void export_atom(python_module_reference m) {
     using coord_fxn = coord_reference (atom_type::*)(size_type);
 
     python_class_type<atom_type>(m, "Atom")
-      .def(pybind11::init<>())
-      .def(pybind11::init<name_type, atomic_number_type, mass_type, coord_type,
-                          coord_type, coord_type>())
-      .def(pybind11::init<name_type, atomic_number_type, mass_type, coord_type,
-                          coord_type, coord_type, charge_type>())
-      .def(pybind11::init<name_type, atomic_number_type, mass_type, coord_type,
-                          coord_type, coord_type, charge_type, size_type>())
+      .def(py::init<>())
+      .def(py::init<name_type, atomic_number_type, mass_type, coord_type,
+                    coord_type, coord_type>())
+      .def(py::init<name_type, atomic_number_type, mass_type, coord_type,
+                    coord_type, coord_type, charge_type>())
+      .def(py::init<name_type, atomic_number_type, mass_type, coord_type,
+                    coord_type, coord_type, charge_type, size_type>())
       .def_property(
         "name", [](atom_reference self) { return self.name(); },
         [](atom_reference self, name_type name) { self.name() = name; })
@@ -81,8 +80,8 @@ void export_atom(python_module_reference m) {
                stream << atom;
                return stream.str();
            })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/molecule/export_molecule.hpp
+++ b/src/python/molecule/export_molecule.hpp
@@ -20,7 +20,13 @@
 namespace chemist {
 
 void export_atom(python_module_reference m);
-void export_molecule(python_module_reference m);
+void export_molecule_class(python_module_reference m);
 void export_molecule_view(python_module_reference m);
+
+inline void export_molecule(python_module_reference m) {
+    export_atom(m);
+    export_molecule_class(m);
+    export_molecule_view(m);
+}
 
 } // namespace chemist

--- a/src/python/molecule/export_molecule_class.cpp
+++ b/src/python/molecule/export_molecule_class.cpp
@@ -17,13 +17,12 @@
 #include "export_molecule.hpp"
 #include <chemist/molecule/molecule.hpp>
 #include <chemist/nucleus/nuclei.hpp>
-#include <pybind11/operators.h>
 #include <sstream>
 #include <vector>
 
 namespace chemist {
-namespace detail_ {
-void export_molecule_(python_module_reference m) {
+
+void export_molecule_class(python_module_reference m) {
     using molecule_type      = Molecule;
     using molecule_reference = molecule_type&;
     using atom_type          = typename Molecule::atom_type;
@@ -36,7 +35,7 @@ void export_molecule_(python_module_reference m) {
     // easier to read
     //@{
     auto value_ctor = [](charge_type q, multiplicity_type m,
-                         pybind11::list py_atoms) {
+                         py::list py_atoms) {
         auto atoms = pybind_to_buffer<atom_type>(py_atoms);
         nuclei_type nuclei;
         for(auto& atom_i : atoms) nuclei.push_back(atom_i.nucleus());
@@ -68,25 +67,25 @@ void export_molecule_(python_module_reference m) {
     };
 
     auto iter_fxn = [](molecule_reference self) {
-        return pybind11::make_iterator(self.begin(), self.end());
+        return py::make_iterator(self.begin(), self.end());
     };
     //@}
 
-    pybind11::keep_alive<0, 1> ka;
+    py::keep_alive<0, 1> ka;
 
     python_class_type<Molecule>(m, "Molecule")
-      .def(pybind11::init<>())
-      .def(pybind11::init<charge_type, size_type, nuclei_type>())
-      .def(pybind11::init(value_ctor))
+      .def(py::init<>())
+      .def(py::init<charge_type, size_type, nuclei_type>())
+      .def(py::init(value_ctor))
       .def("empty", [](molecule_reference self) { return self.empty(); })
       .def("push_back", push_back)
       .def("get_nuclei", get_nuclei_fxn, ka)
       .def("set_nuclei", set_nuclei_fxn)
-      .def_property(
-        "nuclei",
-        pybind11::cpp_function(
-          get_nuclei_fxn, pybind11::return_value_policy::take_ownership, ka),
-        pybind11::cpp_function(set_nuclei_fxn))
+      .def_property("nuclei",
+                    py::cpp_function(get_nuclei_fxn,
+                                     py::return_value_policy::take_ownership,
+                                     ka),
+                    py::cpp_function(set_nuclei_fxn))
       .def("at", at_fxn, ka)
       .def("size", [](molecule_reference self) { return self.size(); })
       .def("charge", &Molecule::charge)
@@ -96,15 +95,8 @@ void export_molecule_(python_module_reference m) {
       .def("set_multiplicity", set_mult)
       .def("__str__", str_fxn)
       .def("__iter__", iter_fxn, ka)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
-}
-} // namespace detail_
-
-void export_molecule(python_module_reference m) {
-    export_atom(m);
-    detail_::export_molecule_(m);
-    export_molecule_view(m);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/molecule/export_molecule_view.cpp
+++ b/src/python/molecule/export_molecule_view.cpp
@@ -17,7 +17,6 @@
 #include "export_molecule.hpp"
 #include <chemist/molecule/molecule_view.hpp>
 #include <chemist/nucleus/nuclei.hpp>
-#include <pybind11/operators.h>
 #include <sstream>
 #include <vector>
 
@@ -37,13 +36,13 @@ void export_molecule_view(python_module_reference m) {
     };
 
     python_class_type<view_type>(m, "MoleculeView")
-      .def(pybind11::init<>())
-      .def(pybind11::init<molecule_type&>())
+      .def(py::init<>())
+      .def(py::init<molecule_type&>())
       .def("empty", [](reference self) { return self.empty(); })
       .def_property("nuclei", get_nuclei_fxn, set_nuclei_fxn)
       .def(
         "at", [](reference self, size_type i) { return self[i]; },
-        pybind11::keep_alive<0, 1>())
+        py::keep_alive<0, 1>())
       .def("size", [](reference self) { return self.size(); })
       .def("charge", &view_type::charge)
       .def("n_electrons", &view_type::n_electrons)
@@ -55,12 +54,12 @@ void export_molecule_view(python_module_reference m) {
       .def(
         "__iter__",
         [](reference self) {
-            return pybind11::make_iterator(self.begin(), self.end());
+            return py::make_iterator(self.begin(), self.end());
         },
-        pybind11::keep_alive<0, 1>())
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == molecule_type{})
-      .def(pybind11::self != pybind11::self);
+        py::keep_alive<0, 1>())
+      .def(py::self == py::self)
+      .def(py::self == molecule_type{})
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/nucleus/export_nuclei.cpp
+++ b/src/python/nucleus/export_nuclei.cpp
@@ -16,7 +16,6 @@
 
 #include "export_nucleus.hpp"
 #include <chemist/nucleus/nuclei.hpp>
-#include <pybind11/operators.h>
 #include <sstream>
 
 namespace chemist {
@@ -33,7 +32,7 @@ void export_nuclei(python_module_reference m) {
 
     // Factor long functions out for readability
     //{
-    auto list_ctor = [](pybind11::list nuclei) {
+    auto list_ctor = [](py::list nuclei) {
         std::vector<value_type> values;
         for(auto& nucleus_py : nuclei) {
             auto nucleus_i = nucleus_py.cast<value_type>();
@@ -56,20 +55,20 @@ void export_nuclei(python_module_reference m) {
         return stream.str();
     };
     auto iter_fxn = [](nuclei_reference self) {
-        return pybind11::make_iterator(self.begin(), self.end());
+        return py::make_iterator(self.begin(), self.end());
     };
     //}
 
-    pybind11::keep_alive<0, 1> ka;
+    py::keep_alive<0, 1> ka;
 
     python_class_type<nuclei_type>(m, "Nuclei")
-      .def(pybind11::init<>())
-      .def(pybind11::init(list_ctor))
-      .def_property(
-        "charges",
-        pybind11::cpp_function(
-          get_charges_fxn, pybind11::return_value_policy::take_ownership, ka),
-        pybind11::cpp_function(set_charges_fxn))
+      .def(py::init<>())
+      .def(py::init(list_ctor))
+      .def_property("charges",
+                    py::cpp_function(get_charges_fxn,
+                                     py::return_value_policy::take_ownership,
+                                     ka),
+                    py::cpp_function(set_charges_fxn))
       .def("empty", [](nuclei_reference self) { return self.empty(); })
       .def("push_back", push_back)
       .def("at", [](nuclei_reference self, size_type i) { return self[i]; })
@@ -77,8 +76,8 @@ void export_nuclei(python_module_reference m) {
       .def("__repr__", str_fxn)
       .def("__str__", str_fxn)
       .def("__iter__", iter_fxn, ka)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/nucleus/export_nuclei_view.cpp
+++ b/src/python/nucleus/export_nuclei_view.cpp
@@ -16,7 +16,6 @@
 
 #include "export_nucleus.hpp"
 #include <chemist/nucleus/nuclei_view.hpp>
-#include <pybind11/operators.h>
 #include <sstream>
 
 namespace chemist {
@@ -37,8 +36,8 @@ void export_nuclei_view_(const char* name, python_module_reference m) {
     using other_view_type = NucleiView<other_nuclei_type>;
 
     python_class_type<view_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<nuclei_type&>())
+      .def(py::init<>())
+      .def(py::init<nuclei_type&>())
       .def("empty", [](reference self) { return self.empty(); })
       .def("at", [](reference self, size_type i) { return self[i]; })
       .def("size", [](reference self) { return self.size(); })
@@ -52,17 +51,17 @@ void export_nuclei_view_(const char* name, python_module_reference m) {
       .def(
         "__iter__",
         [](reference self) {
-            return pybind11::make_iterator(self.begin(), self.end());
+            return py::make_iterator(self.begin(), self.end());
         },
-        pybind11::keep_alive<0, 1>())
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == nuclei_type{})
-      .def(nuclei_type{} == pybind11::self)
-      .def(pybind11::self == other_view_type{})
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != nuclei_type{})
-      .def(nuclei_type{} != pybind11::self)
-      .def(pybind11::self != other_view_type{});
+        py::keep_alive<0, 1>())
+      .def(py::self == py::self)
+      .def(py::self == nuclei_type{})
+      .def(nuclei_type{} == py::self)
+      .def(py::self == other_view_type{})
+      .def(py::self != py::self)
+      .def(py::self != nuclei_type{})
+      .def(nuclei_type{} != py::self)
+      .def(py::self != other_view_type{});
 }
 
 } // namespace detail_

--- a/src/python/nucleus/export_nucleus.cpp
+++ b/src/python/nucleus/export_nucleus.cpp
@@ -16,12 +16,11 @@
 
 #include "export_nucleus.hpp"
 #include <chemist/nucleus/nucleus.hpp>
-#include <pybind11/operators.h>
 #include <sstream>
 
 namespace chemist {
 
-void export_nucleus(python_module_reference m) {
+void export_nucleus_class(python_module_reference m) {
     using nucleus_type       = Nucleus;
     using nucleus_reference  = nucleus_type&;
     using point_charge_type  = typename Nucleus::point_charge_type;
@@ -32,12 +31,12 @@ void export_nucleus(python_module_reference m) {
     using charge_type        = typename Nucleus::charge_type;
 
     python_class_type<nucleus_type, point_charge_type>(m, "Nucleus")
-      .def(pybind11::init<>())
-      .def(pybind11::init<name_type, atomic_number_type, mass_type>())
-      .def(pybind11::init<name_type, atomic_number_type, mass_type, coord_type,
-                          coord_type, coord_type>())
-      .def(pybind11::init<name_type, atomic_number_type, mass_type, coord_type,
-                          coord_type, coord_type, charge_type>())
+      .def(py::init<>())
+      .def(py::init<name_type, atomic_number_type, mass_type>())
+      .def(py::init<name_type, atomic_number_type, mass_type, coord_type,
+                    coord_type, coord_type>())
+      .def(py::init<name_type, atomic_number_type, mass_type, coord_type,
+                    coord_type, coord_type, charge_type>())
       .def_property(
         "name", [](nucleus_reference self) { return self.name(); },
         [](nucleus_reference self, name_type name) {
@@ -55,12 +54,8 @@ void export_nucleus(python_module_reference m) {
                stream << nuc;
                return stream.str();
            })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
-
-    export_nucleus_view(m);
-    export_nuclei(m);
-    export_nuclei_view(m);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist

--- a/src/python/nucleus/export_nucleus.hpp
+++ b/src/python/nucleus/export_nucleus.hpp
@@ -19,9 +19,16 @@
 
 namespace chemist {
 
-void export_nucleus(python_module_reference m);
+void export_nucleus_class(python_module_reference m);
 void export_nucleus_view(python_module_reference m);
 void export_nuclei(python_module_reference m);
 void export_nuclei_view(python_module_reference m);
+
+inline void export_nucleus(python_module_reference m) {
+    export_nucleus_class(m);
+    export_nucleus_view(m);
+    export_nuclei(m);
+    export_nuclei_view(m);
+}
 
 } // namespace chemist

--- a/src/python/nucleus/export_nucleus_view.cpp
+++ b/src/python/nucleus/export_nucleus_view.cpp
@@ -16,7 +16,6 @@
 
 #include "export_nucleus.hpp"
 #include <chemist/nucleus/nucleus_view.hpp>
-#include <pybind11/operators.h>
 #include <sstream>
 
 namespace chemist {
@@ -34,7 +33,7 @@ void export_mutable_view(python_module_reference m) {
     using mass_type          = typename view_type::mass_type;
 
     python_class_type<view_type, charge_view_type>(m, "NucleusView")
-      .def(pybind11::init<nucleus_reference>())
+      .def(py::init<nucleus_reference>())
       .def_property(
         "name", [](view_reference self) { return self.name(); },
         [](view_reference self, name_type name) {
@@ -52,12 +51,12 @@ void export_mutable_view(python_module_reference m) {
                stream << nv;
                return stream.str();
            })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == nucleus_type())
-      .def(nucleus_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != nucleus_type())
-      .def(nucleus_type() != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self == nucleus_type())
+      .def(nucleus_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != nucleus_type())
+      .def(nucleus_type() != py::self);
 }
 
 void export_immutable_view(python_module_reference m) {
@@ -68,7 +67,7 @@ void export_immutable_view(python_module_reference m) {
     using charge_view_type  = typename view_type::charge_view_type;
 
     python_class_type<view_type, charge_view_type>(m, "ImmutableNucleusView")
-      .def(pybind11::init<nucleus_reference>())
+      .def(py::init<nucleus_reference>())
       .def_property_readonly("name",
                              [](view_reference self) { return self.name(); })
       .def_property_readonly("Z", [](view_reference self) { return self.Z(); })
@@ -80,12 +79,12 @@ void export_immutable_view(python_module_reference m) {
                stream << nv;
                return stream.str();
            })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == nucleus_type())
-      .def(nucleus_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != nucleus_type())
-      .def(nucleus_type() != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self == nucleus_type())
+      .def(nucleus_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != nucleus_type())
+      .def(nucleus_type() != py::self);
 }
 
 } // namespace detail_

--- a/src/python/point/export_point.hpp
+++ b/src/python/point/export_point.hpp
@@ -16,50 +16,16 @@
 
 #pragma once
 #include "../pychemist.hpp"
-#include <chemist/point/point.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
-namespace detail_ {
 
-template<typename T>
-inline void export_point_(const char* name, python_module_reference m) {
-    using point_type      = Point<T>;
-    using coord_type      = typename point_type::coord_type;
-    using coord_reference = typename point_type::coord_reference;
-    using size_type       = typename point_type::size_type;
-
-    using coord_fxn = coord_reference (point_type::*)(size_type);
-
-    python_class_type<point_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<coord_type, coord_type, coord_type>())
-      .def("coord", static_cast<coord_fxn>(&point_type::coord))
-      .def_property(
-        "x", [](point_type& p) { return p.x(); },
-        [](point_type& p, coord_type x) { p.x() = x; })
-      .def_property(
-        "y", [](point_type& p) { return p.y(); },
-        [](point_type& p, coord_type y) { p.y() = y; })
-      .def_property(
-        "z", [](point_type& p) { return p.z(); },
-        [](point_type& p, coord_type z) { p.z() = z; })
-      .def("magnitude", &point_type::magnitude)
-      .def(pybind11::self - pybind11::self)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
-}
-
-} // namespace detail_
-
+void export_point_class(python_module_reference m);
 void export_point_set(python_module_reference m);
 void export_point_set_view(python_module_reference m);
 void export_point_view(python_module_reference m);
 
 inline void export_point(python_module_reference m) {
-    detail_::export_point_<float>("PointF", m);
-    detail_::export_point_<double>("PointD", m);
-
+    export_point_class(m);
     export_point_view(m);
     export_point_set(m);
     export_point_set_view(m);

--- a/src/python/point/export_point_class.cpp
+++ b/src/python/point/export_point_class.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "export_point.hpp"
+#include <chemist/point/point.hpp>
+
+namespace chemist {
+
+namespace detail_ {
+
+template<typename T>
+inline void export_point_(const char* name, python_module_reference m) {
+    using point_type      = Point<T>;
+    using coord_type      = typename point_type::coord_type;
+    using coord_reference = typename point_type::coord_reference;
+    using size_type       = typename point_type::size_type;
+
+    using coord_fxn = coord_reference (point_type::*)(size_type);
+
+    python_class_type<point_type>(m, name)
+      .def(py::init<>())
+      .def(py::init<coord_type, coord_type, coord_type>())
+      .def("coord", static_cast<coord_fxn>(&point_type::coord))
+      .def_property(
+        "x", [](point_type& p) { return p.x(); },
+        [](point_type& p, coord_type x) { p.x() = x; })
+      .def_property(
+        "y", [](point_type& p) { return p.y(); },
+        [](point_type& p, coord_type y) { p.y() = y; })
+      .def_property(
+        "z", [](point_type& p) { return p.z(); },
+        [](point_type& p, coord_type z) { p.z() = z; })
+      .def("magnitude", &point_type::magnitude)
+      .def(py::self - py::self)
+      .def(py::self == py::self)
+      .def(py::self != py::self);
+}
+
+} // namespace detail_
+
+void export_point_class(python_module_reference m) {
+    detail_::export_point_<float>("PointF", m);
+    detail_::export_point_<double>("PointD", m);
+}
+
+} // namespace chemist

--- a/src/python/point/export_point_set.cpp
+++ b/src/python/point/export_point_set.cpp
@@ -18,6 +18,7 @@
 #include <chemist/point/point_set.hpp>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -31,7 +32,7 @@ void export_point_set_(const char* name, python_module_reference m) {
     using size_type           = typename point_set_type::size_type;
 
     python_class_type<point_set_type>(m, name)
-      .def(pybind11::init<>())
+      .def(py::init<>())
       .def("empty", [](point_set_reference self) { return self.empty(); })
       .def("push_back",
            [](point_set_reference self, value_type v) {
@@ -39,8 +40,8 @@ void export_point_set_(const char* name, python_module_reference m) {
            })
       .def("at", [](point_set_reference self, size_type i) { return self[i]; })
       .def("size", [](point_set_reference self) { return self.size(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace detail_

--- a/src/python/point/export_point_set_view.cpp
+++ b/src/python/point/export_point_set_view.cpp
@@ -18,7 +18,9 @@
 #include <chemist/point/point_set_view.hpp>
 
 namespace chemist {
+
 namespace detail_ {
+
 template<typename T>
 void export_point_set_view_(const char* name, python_module_reference m) {
     using point_set_view_type = PointSetView<PointSet<T>>;
@@ -27,14 +29,14 @@ void export_point_set_view_(const char* name, python_module_reference m) {
     using size_type           = typename point_set_view_type::size_type;
 
     python_class_type<point_set_view_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<point_set_type&>())
+      .def(py::init<>())
+      .def(py::init<point_set_type&>())
       .def("empty", [](reference self) { return self.empty(); })
       .def("at", [](reference self, size_type i) { return self[i]; })
       .def("size", [](reference self) { return self.size(); })
       .def("as_point_set", [](reference self) { return self.as_point_set(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace detail_

--- a/src/python/point/export_point_view.cpp
+++ b/src/python/point/export_point_view.cpp
@@ -16,9 +16,9 @@
 
 #include "export_point.hpp"
 #include <chemist/point/point_view.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -32,7 +32,7 @@ inline void export_mutable_(const char* name, python_module_reference m) {
     using coord_fxn = coord_reference (point_view_type::*)(size_type);
 
     python_class_type<point_view_type>(m, name)
-      .def(pybind11::init<point_type&>())
+      .def(py::init<point_type&>())
       .def("coord", static_cast<coord_fxn>(&point_view_type::coord))
       .def_property(
         "x", [](point_view_type& p) { return p.x(); },
@@ -44,11 +44,11 @@ inline void export_mutable_(const char* name, python_module_reference m) {
         "z", [](point_view_type& p) { return p.z(); },
         [](point_view_type& p, coord_type z) { p.z() = z; })
       .def("magnitude", &point_view_type::magnitude)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == point_type())
-      .def(point_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != point_type());
+      .def(py::self == py::self)
+      .def(py::self == point_type())
+      .def(point_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != point_type());
 }
 
 template<typename T>
@@ -61,17 +61,17 @@ inline void export_immutable_(const char* name, python_module_reference m) {
     using coord_fxn = coord_reference (point_view_type::*)(size_type);
 
     python_class_type<point_view_type>(m, name)
-      .def(pybind11::init<point_type&>())
+      .def(py::init<point_type&>())
       .def("coord", static_cast<coord_fxn>(&point_view_type::coord))
       .def_property_readonly("x", [](point_view_type& p) { return p.x(); })
       .def_property_readonly("y", [](point_view_type& p) { return p.y(); })
       .def_property_readonly("z", [](point_view_type& p) { return p.z(); })
       .def("magnitude", &point_view_type::magnitude)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == point_type())
-      .def(point_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != point_type());
+      .def(py::self == py::self)
+      .def(py::self == point_type())
+      .def(point_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != point_type());
 }
 
 } // namespace detail_

--- a/src/python/point_charge/export_charge_view.cpp
+++ b/src/python/point_charge/export_charge_view.cpp
@@ -16,9 +16,9 @@
 
 #include "export_point_charge.hpp"
 #include <chemist/point_charge/point_charge_view.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -31,16 +31,16 @@ void export_mutable_view_(const char* name, python_module_reference m) {
     using point_view_type = typename charge_view_type::point_view_type;
 
     python_class_type<charge_view_type, point_view_type>(m, name)
-      .def(pybind11::init<point_charge_reference>())
+      .def(py::init<point_charge_reference>())
       .def_property(
         "charge", [](charge_view_type& self) { return self.charge(); },
         [](charge_view_type& self, charge_type q) { self.charge() = q; })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == point_charge_type())
-      .def(point_charge_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != point_charge_type())
-      .def(point_charge_type() != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self == point_charge_type())
+      .def(point_charge_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != point_charge_type())
+      .def(point_charge_type() != py::self);
 }
 
 template<typename T>
@@ -52,15 +52,15 @@ void export_immutable_view_(const char* name, python_module_reference m) {
     using point_view_type = typename charge_view_type::point_view_type;
 
     python_class_type<charge_view_type, point_view_type>(m, name)
-      .def(pybind11::init<point_charge_reference>())
+      .def(py::init<point_charge_reference>())
       .def_property_readonly(
         "charge", [](charge_view_type& self) { return self.charge(); })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == point_charge_type())
-      .def(point_charge_type() == pybind11::self)
-      .def(pybind11::self != pybind11::self)
-      .def(pybind11::self != point_charge_type())
-      .def(point_charge_type() != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self == point_charge_type())
+      .def(point_charge_type() == py::self)
+      .def(py::self != py::self)
+      .def(py::self != point_charge_type())
+      .def(point_charge_type() != py::self);
 }
 
 } // namespace detail_

--- a/src/python/point_charge/export_charges.cpp
+++ b/src/python/point_charge/export_charges.cpp
@@ -16,10 +16,10 @@
 
 #include "export_point_charge.hpp"
 #include <chemist/point_charge/charges.hpp>
-#include <pybind11/operators.h>
 #include <sstream>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -39,7 +39,7 @@ void export_charges_(const char* name, python_module_reference m) {
     };
 
     python_class_type<charges_type>(m, name)
-      .def(pybind11::init<>())
+      .def(py::init<>())
       .def("empty", [](charges_reference self) { return self.empty(); })
       .def("push_back",
            [](charges_reference self, value_type v) {
@@ -48,8 +48,8 @@ void export_charges_(const char* name, python_module_reference m) {
       .def("at", [](charges_reference self, size_type i) { return self[i]; })
       .def("size", [](charges_reference self) { return self.size(); })
       .def("__str__", str_fxn)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace detail_

--- a/src/python/point_charge/export_charges_view.cpp
+++ b/src/python/point_charge/export_charges_view.cpp
@@ -16,10 +16,10 @@
 
 #include "export_point_charge.hpp"
 #include <chemist/point_charge/charges_view.hpp>
-#include <pybind11/operators.h>
 #include <sstream>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -41,23 +41,23 @@ void export_charges_view_(const char* name, python_module_reference m) {
         return stream.str();
     };
 
-    pybind11::keep_alive<0, 1> ka;
+    py::keep_alive<0, 1> ka;
 
     python_class_type<view_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<charges_type&>())
-      .def_property(
-        "point_set",
-        pybind11::cpp_function(
-          get_point_set_fxn, pybind11::return_value_policy::take_ownership, ka),
-        pybind11::cpp_function(set_point_set_fxn))
+      .def(py::init<>())
+      .def(py::init<charges_type&>())
+      .def_property("point_set",
+                    py::cpp_function(get_point_set_fxn,
+                                     py::return_value_policy::take_ownership,
+                                     ka),
+                    py::cpp_function(set_point_set_fxn))
       .def("empty", [](reference self) { return self.empty(); })
       .def("at", [](reference self, size_type i) { return self[i]; })
       .def("size", [](reference self) { return self.size(); })
       .def("__str__", str_fxn)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self == charges_type())
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self == charges_type())
+      .def(py::self != py::self);
 }
 
 } // namespace detail_

--- a/src/python/point_charge/export_point_charge.cpp
+++ b/src/python/point_charge/export_point_charge.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "export_point_charge.hpp"
-#include <pybind11/operators.h>
 
 namespace chemist {
+
 namespace detail_ {
 
 template<typename T>
@@ -28,24 +28,20 @@ void export_point_charge_(const char* name, python_module_reference m) {
     using coord_type        = typename point_charge_type::coord_type;
 
     python_class_type<point_charge_type, point_type>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<charge_type, coord_type, coord_type, coord_type>())
+      .def(py::init<>())
+      .def(py::init<charge_type, coord_type, coord_type, coord_type>())
       .def_property(
         "charge", [](point_charge_type& self) { return self.charge(); },
         [](point_charge_type& self, charge_type q) { self.charge() = q; })
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace detail_
 
-void export_point_charge(python_module_reference m) {
+void export_point_charge_class(python_module_reference m) {
     detail_::export_point_charge_<float>("PointChargeF", m);
     detail_::export_point_charge_<double>("PointChargeD", m);
-
-    export_charge_view(m);
-    export_charges(m);
-    export_charges_view(m);
 }
 
 } // namespace chemist

--- a/src/python/point_charge/export_point_charge.hpp
+++ b/src/python/point_charge/export_point_charge.hpp
@@ -23,6 +23,13 @@ namespace chemist {
 void export_charge_view(python_module_reference m);
 void export_charges(python_module_reference m);
 void export_charges_view(python_module_reference m);
-void export_point_charge(python_module_reference m);
+void export_point_charge_class(python_module_reference m);
+
+inline void export_point_charge(python_module_reference m) {
+    export_point_charge_class(m);
+    export_charge_view(m);
+    export_charges(m);
+    export_charges_view(m);
+}
 
 } // namespace chemist

--- a/src/python/pychemist.hpp
+++ b/src/python/pychemist.hpp
@@ -16,19 +16,23 @@
 
 #pragma once
 #include <pybind11/native_enum.h>
+#include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace chemist {
 
-using python_module_type = pybind11::module_;
+namespace py = pybind11;
+
+using python_module_type = py::module_;
 
 using python_module_reference = python_module_type&;
 
 template<typename... Args>
-using python_class_type = pybind11::class_<Args...>;
+using python_class_type = py::class_<Args...>;
 
 template<typename... Args>
-using python_enum_type = pybind11::native_enum<Args...>;
+using python_enum_type = py::native_enum<Args...>;
 
 /** @brief Convenience function for checking if a pybind11 object can be
  *         cast to  type T
@@ -99,7 +103,7 @@ auto pybind_to_buffer(U container) {
  *                        throw guarantee.
  */
 template<typename T>
-auto args_to_buffer(pybind11::args args) {
+auto args_to_buffer(py::args args) {
     return pybind_to_buffer<T>(args);
 }
 

--- a/src/python/quantum_mechanics/operator/export_coulomb.cpp
+++ b/src/python/quantum_mechanics/operator/export_coulomb.cpp
@@ -16,9 +16,10 @@
 
 #include "export_operator.hpp"
 #include <chemist/quantum_mechanics/operator/coulomb.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::qm_operator {
+
+namespace detail_ {
 
 template<typename T, typename U>
 void export_coulomb_(const char* name, python_module_reference m) {
@@ -34,30 +35,33 @@ void export_coulomb_(const char* name, python_module_reference m) {
     };
     auto set_rhs_particle = [](coulomb_t& o, U& p) { o.set_rhs_particle(p); };
 
-    python_class_type<coulomb_t, op_base_t, pybind11::smart_holder>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<T, U>())
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self)
+    python_class_type<coulomb_t, op_base_t, py::smart_holder>(m, name)
+      .def(py::init<>())
+      .def(py::init<T, U>())
+      .def(py::self == py::self)
+      .def(py::self != py::self)
       .def_property("lhs_particle", get_lhs_particle, set_lhs_particle)
       .def_property("rhs_particle", get_rhs_particle, set_rhs_particle);
 }
 
+} // namespace detail_
+
 void export_coulomb(python_module_reference m) {
-    export_coulomb_<Electron, Electron>("CoulombElectronElectron", m);
-    export_coulomb_<ManyElectrons, ManyElectrons>(
+    detail_::export_coulomb_<Electron, Electron>("CoulombElectronElectron", m);
+    detail_::export_coulomb_<ManyElectrons, ManyElectrons>(
       "CoulombManyElectronsManyElectrons", m);
-    export_coulomb_<Electron, chemist::Density<Electron>>(
+    detail_::export_coulomb_<Electron, chemist::Density<Electron>>(
       "CoulombElectronDensityElectron", m);
-    export_coulomb_<ManyElectrons, chemist::Density<Electron>>(
+    detail_::export_coulomb_<ManyElectrons, chemist::Density<Electron>>(
       "CoulombManyElectronsDensityElectrons", m);
-    export_coulomb_<Electron, DecomposableDensity<Electron>>(
+    detail_::export_coulomb_<Electron, DecomposableDensity<Electron>>(
       "CoulombElectronDecomposableDensityElectron", m);
-    export_coulomb_<ManyElectrons, DecomposableDensity<Electron>>(
+    detail_::export_coulomb_<ManyElectrons, DecomposableDensity<Electron>>(
       "CoulombManyElectronsDecomposableDensityElectron", m);
-    export_coulomb_<Electron, Nuclei>("CoulombElectronNuclei", m);
-    export_coulomb_<ManyElectrons, Nuclei>("CoulombManyElectronsNuclei", m);
-    export_coulomb_<Nuclei, Nuclei>("CoulombNucleiNuclei", m);
+    detail_::export_coulomb_<Electron, Nuclei>("CoulombElectronNuclei", m);
+    detail_::export_coulomb_<ManyElectrons, Nuclei>(
+      "CoulombManyElectronsNuclei", m);
+    detail_::export_coulomb_<Nuclei, Nuclei>("CoulombNucleiNuclei", m);
 }
 
 } // namespace chemist::qm_operator

--- a/src/python/quantum_mechanics/operator/export_exchange.cpp
+++ b/src/python/quantum_mechanics/operator/export_exchange.cpp
@@ -16,9 +16,10 @@
 
 #include "export_operator.hpp"
 #include <chemist/quantum_mechanics/operator/exchange.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::qm_operator {
+
+namespace detail_ {
 
 template<typename T, typename U>
 void export_exchange_(const char* name, python_module_reference m) {
@@ -34,23 +35,25 @@ void export_exchange_(const char* name, python_module_reference m) {
     };
     auto set_rhs_particle = [](exchange_t& o, U& p) { o.set_rhs_particle(p); };
 
-    python_class_type<exchange_t, op_base_t, pybind11::smart_holder>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<T, U>())
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self)
+    python_class_type<exchange_t, op_base_t, py::smart_holder>(m, name)
+      .def(py::init<>())
+      .def(py::init<T, U>())
+      .def(py::self == py::self)
+      .def(py::self != py::self)
       .def_property("lhs_particle", get_lhs_particle, set_lhs_particle)
       .def_property("rhs_particle", get_rhs_particle, set_rhs_particle);
 }
 
+} // namespace detail_
+
 void export_exchange(python_module_reference m) {
-    export_exchange_<Electron, chemist::Density<Electron>>(
+    detail_::export_exchange_<Electron, chemist::Density<Electron>>(
       "ExchangeElectronDensityElectron", m);
-    export_exchange_<ManyElectrons, chemist::Density<Electron>>(
+    detail_::export_exchange_<ManyElectrons, chemist::Density<Electron>>(
       "ExchangeManyElectronsDensityElectron", m);
-    export_exchange_<Electron, DecomposableDensity<Electron>>(
+    detail_::export_exchange_<Electron, DecomposableDensity<Electron>>(
       "ExchangeElectronDecomposableDensityElectron", m);
-    export_exchange_<ManyElectrons, DecomposableDensity<Electron>>(
+    detail_::export_exchange_<ManyElectrons, DecomposableDensity<Electron>>(
       "ExchangeManyElectronsDecomposableDensityElectron", m);
 }
 

--- a/src/python/quantum_mechanics/operator/export_exchange_correlation.cpp
+++ b/src/python/quantum_mechanics/operator/export_exchange_correlation.cpp
@@ -16,10 +16,10 @@
 
 #include "export_operator.hpp"
 #include <chemist/quantum_mechanics/operator/exchange_correlation.hpp>
-#include <pybind11/native_enum.h>
-#include <pybind11/operators.h>
 
 namespace chemist::qm_operator {
+
+namespace detail_ {
 
 void export_xc_functionals_(python_module_reference m) {
     python_enum_type<xc_functional>(m, "xc_functional", "enum.Enum")
@@ -51,27 +51,32 @@ void export_exchange_correlation_(const char* name, python_module_reference m) {
         o.set_functional_name(p);
     };
 
-    python_class_type<xc_t, op_base_t, pybind11::smart_holder>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<xc_functional, T, U>())
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self)
+    python_class_type<xc_t, op_base_t, py::smart_holder>(m, name)
+      .def(py::init<>())
+      .def(py::init<xc_functional, T, U>())
+      .def(py::self == py::self)
+      .def(py::self != py::self)
       .def_property("lhs_particle", get_lhs_particle, set_lhs_particle)
       .def_property("rhs_particle", get_rhs_particle, set_rhs_particle)
       .def_property("functional_name", get_functional_name,
                     set_functional_name);
 }
 
-void export_exchange_correlation(python_module_reference m) {
-    export_xc_functionals_(m);
+} // namespace detail_
 
-    export_exchange_correlation_<Electron, chemist::Density<Electron>>(
+void export_exchange_correlation(python_module_reference m) {
+    detail_::export_xc_functionals_(m);
+
+    detail_::export_exchange_correlation_<Electron, chemist::Density<Electron>>(
       "ExchangeCorrelationElectronDensityElectron", m);
-    export_exchange_correlation_<ManyElectrons, chemist::Density<Electron>>(
+    detail_::export_exchange_correlation_<ManyElectrons,
+                                          chemist::Density<Electron>>(
       "ExchangeCorrelationManyElectronsDensityElectrons", m);
-    export_exchange_correlation_<Electron, DecomposableDensity<Electron>>(
+    detail_::export_exchange_correlation_<Electron,
+                                          DecomposableDensity<Electron>>(
       "ExchangeCorrelationElectronDecomposableDensityElectron", m);
-    export_exchange_correlation_<ManyElectrons, DecomposableDensity<Electron>>(
+    detail_::export_exchange_correlation_<ManyElectrons,
+                                          DecomposableDensity<Electron>>(
       "ExchangeCorrelationManyElectronsDecomposableDensityElectron", m);
 }
 

--- a/src/python/quantum_mechanics/operator/export_hamiltonians.cpp
+++ b/src/python/quantum_mechanics/operator/export_hamiltonians.cpp
@@ -18,9 +18,10 @@
 #include <chemist/quantum_mechanics/operator/core_hamiltonian.hpp>
 #include <chemist/quantum_mechanics/operator/electronic_hamiltonian.hpp>
 #include <chemist/quantum_mechanics/operator/hamiltonian.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::qm_operator {
+
+namespace detail_ {
 
 template<typename HamiltonianType>
 void export_hamiltonian_(const char* name, python_module_reference m) {
@@ -40,16 +41,16 @@ void export_hamiltonian_(const char* name, python_module_reference m) {
         self.emplace_back(c, std::move(op));
     };
 
-    pybind11::keep_alive<0, 1> ka;
+    py::keep_alive<0, 1> ka;
 
-    auto c = python_class_type<h_t, op_base_t, pybind11::smart_holder>(m, name)
-               .def(pybind11::init<>())
+    auto c = python_class_type<h_t, op_base_t, py::smart_holder>(m, name)
+               .def(py::init<>())
                .def("size", size_fn)
                .def("coefficient", coeff_fn)
                .def("get_operator", get_op_fn, ka)
                .def("emplace_back", emplace_back_fn)
-               .def(pybind11::self == pybind11::self)
-               .def(pybind11::self != pybind11::self);
+               .def(py::self == py::self)
+               .def(py::self != py::self);
 
     if constexpr(!std::is_same_v<h_t, CoreHamiltonian>) {
         auto core_hamiltonian_fn = [](const h_t& self) {
@@ -66,16 +67,19 @@ void export_hamiltonian_(const char* name, python_module_reference m) {
     }
 }
 
+} // namespace detail_
+
 void export_core_hamiltonian(python_module_reference m) {
-    export_hamiltonian_<CoreHamiltonian>("CoreHamiltonian", m);
+    detail_::export_hamiltonian_<CoreHamiltonian>("CoreHamiltonian", m);
 }
 
 void export_electronic_hamiltonian(python_module_reference m) {
-    export_hamiltonian_<ElectronicHamiltonian>("ElectronicHamiltonian", m);
+    detail_::export_hamiltonian_<ElectronicHamiltonian>("ElectronicHamiltonian",
+                                                        m);
 }
 
 void export_hamiltonian(python_module_reference m) {
-    export_hamiltonian_<Hamiltonian>("Hamiltonian", m);
+    detail_::export_hamiltonian_<Hamiltonian>("Hamiltonian", m);
 }
 
 } // namespace chemist::qm_operator

--- a/src/python/quantum_mechanics/operator/export_identity.cpp
+++ b/src/python/quantum_mechanics/operator/export_identity.cpp
@@ -16,17 +16,15 @@
 
 #include "export_operator.hpp"
 #include <chemist/quantum_mechanics/operator/identity.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::qm_operator {
 
 void export_identity(python_module_reference m) {
     using op_base_t = OperatorBase;
-    python_class_type<Identity, op_base_t, pybind11::smart_holder>(m,
-                                                                   "Identity")
-      .def(pybind11::init<>())
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+    python_class_type<Identity, op_base_t, py::smart_holder>(m, "Identity")
+      .def(py::init<>())
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist::qm_operator

--- a/src/python/quantum_mechanics/operator/export_kinetic.cpp
+++ b/src/python/quantum_mechanics/operator/export_kinetic.cpp
@@ -16,9 +16,10 @@
 
 #include "export_operator.hpp"
 #include <chemist/quantum_mechanics/operator/kinetic.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::qm_operator {
+
+namespace detail_ {
 
 template<typename T>
 void export_kinetic_(const char* name, python_module_reference m) {
@@ -28,19 +29,21 @@ void export_kinetic_(const char* name, python_module_reference m) {
     auto get_particle = [](const kinetic_t& k) { return k.get_particle(); };
     auto set_particle = [](kinetic_t& k, T& p) { k.set_particle(p); };
 
-    python_class_type<kinetic_t, op_base_t, pybind11::smart_holder>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<T>())
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self)
+    python_class_type<kinetic_t, op_base_t, py::smart_holder>(m, name)
+      .def(py::init<>())
+      .def(py::init<T>())
+      .def(py::self == py::self)
+      .def(py::self != py::self)
       .def_property("particle", get_particle, set_particle);
 }
 
+} // namespace detail_
+
 void export_kinetic(python_module_reference m) {
-    export_kinetic_<Electron>("KineticElectron", m);
-    export_kinetic_<ManyElectrons>("KineticManyElectrons", m);
-    export_kinetic_<Nucleus>("KineticNuclues", m);
-    export_kinetic_<Nuclei>("KineticNuclei", m);
+    detail_::export_kinetic_<Electron>("KineticElectron", m);
+    detail_::export_kinetic_<ManyElectrons>("KineticManyElectrons", m);
+    detail_::export_kinetic_<Nucleus>("KineticNuclues", m);
+    detail_::export_kinetic_<Nuclei>("KineticNuclei", m);
 }
 
 } // namespace chemist::qm_operator

--- a/src/python/quantum_mechanics/operator/export_operator_base.cpp
+++ b/src/python/quantum_mechanics/operator/export_operator_base.cpp
@@ -16,13 +16,12 @@
 
 #include "export_operator.hpp"
 #include <chemist/quantum_mechanics/operator/operator_base.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::qm_operator {
 
 void export_operator_base(python_module_reference m) {
     using base_t = OperatorBase;
-    python_class_type<base_t, pybind11::smart_holder>(m, "OperatorBase")
+    python_class_type<base_t, py::smart_holder>(m, "OperatorBase")
       .def("clone", &base_t::clone)
       .def("are_equal", &base_t::are_equal)
       .def("are_different", &base_t::are_different);

--- a/src/python/quantum_mechanics/wavefunction/export_aos.cpp
+++ b/src/python/quantum_mechanics/wavefunction/export_aos.cpp
@@ -16,7 +16,6 @@
 
 #include "export_wavefunction.hpp"
 #include <chemist/quantum_mechanics/wavefunction/aos.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::wavefunction {
 
@@ -30,11 +29,11 @@ void export_aos(python_module_reference m) {
     };
 
     python_class_type<AOs, VectorSpace>(m, "AOs")
-      .def(pybind11::init<>())
-      .def(pybind11::init<ao_basis_set>())
+      .def(py::init<>())
+      .def(py::init<ao_basis_set>())
       .def_property("ao_basis_set", get_aos, set_aos)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
 
 } // namespace chemist::wavefunction

--- a/src/python/quantum_mechanics/wavefunction/export_tranformed.cpp
+++ b/src/python/quantum_mechanics/wavefunction/export_tranformed.cpp
@@ -16,9 +16,9 @@
 
 #include "export_wavefunction.hpp"
 #include <chemist/quantum_mechanics/wavefunction/wavefunction.hpp>
-#include <pybind11/operators.h>
 
 namespace chemist::wavefunction {
+
 namespace detail_ {
 
 template<typename T>
@@ -41,13 +41,14 @@ void export_transformed_(const char* name, python_module_reference m) {
     python_module_type::import("tensorwrapper");
 
     python_class_type<transformed_t, VectorSpace>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<from_space_t, transform_t>())
+      .def(py::init<>())
+      .def(py::init<from_space_t, transform_t>())
       .def_property("from_space", get_from_space, set_from_space)
       .def_property("transform", get_transform, set_transform)
-      .def(pybind11::self == pybind11::self)
-      .def(pybind11::self != pybind11::self);
+      .def(py::self == py::self)
+      .def(py::self != py::self);
 }
+
 } // namespace detail_
 
 void export_transformed(python_module_reference m) {

--- a/src/python/quantum_mechanics/wavefunction/export_vector_space.cpp
+++ b/src/python/quantum_mechanics/wavefunction/export_vector_space.cpp
@@ -41,7 +41,7 @@ protected:
 
 void export_vector_space(python_module_reference m) {
     python_class_type<VectorSpace, PyVectorSpace>(m, "VectorSpace")
-      .def(pybind11::init<>())
+      .def(py::init<>())
       .def("clone", &VectorSpace::clone)
       .def("size", &VectorSpace::size)
       .def("are_equal", &VectorSpace::are_equal)


### PR DESCRIPTION
**Description**
A lot of this is minor whitespace formatting. There are some meaningful changes to the python bindings, primarily the introduction of the `namespace py = pybind11` alias. The pybind11 headers are also consolidated into `pychemist.hpp` and a few implementation templates were moved into the `detail_` namespace.